### PR TITLE
Update nuget_package_push_prerelease.yml

### DIFF
--- a/.github/workflows/nuget_package_push_prerelease.yml
+++ b/.github/workflows/nuget_package_push_prerelease.yml
@@ -15,7 +15,7 @@ jobs:
         uses: srfrnk/current-time@master
         id: current-time
         with:
-          format: YYYYMMDDHHMMSS
+          format: YYYYMMDDHHmmss
       - uses: actions/checkout@master
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1


### PR DESCRIPTION
See https://github.com/srfrnk/current-time#format and https://momentjs.com/docs/#/displaying/

    MM is month, we want mm = minutes
    SS is fractional second, we want ss = seconds

Both are wrong in the BO4E repo also ;)