### PR TITLE
TST-1268: Add Lieferzeitraum to COM Angebotsteil

### DIFF
--- a/BO4E/BO4Enet.xml
+++ b/BO4E/BO4Enet.xml
@@ -2198,6 +2198,9 @@
         <member name="P:BO4E.COM.Angebotsteil.Positionen">
             <summary>Einzelne Positionen, die zu diesem Angebotsteil gehören. Details <see cref="T:BO4E.COM.Angebotsposition" /></summary>
         </member>
+        <member name="P:BO4E.COM.Angebotsteil.Lieferzeitraum">
+            <summary>Hier kann der Belieferungszeitraum angegeben werden, für den dieser Angebotsteil gilt. Details <see cref="T:BO4E.COM.Zeitraum" /></summary>
+        </member>
         <member name="T:BO4E.COM.Angebotsvariante">
             <summary>Führt die verschiedenen Ausprägungen der Angebotsberechnung auf.</summary>
         </member>

--- a/BO4E/COM/Angebotsteil.cs
+++ b/BO4E/COM/Angebotsteil.cs
@@ -55,6 +55,6 @@ namespace BO4E.COM
         [JsonProperty(PropertyName = "lieferzeitraum", Required = Required.Default)]
         [JsonPropertyName("lieferzeitraum")]
         [ProtoMember(8)]
-        public Zeitraum Lieferzeitraum { get; set; }
+        public Zeitraum? Lieferzeitraum { get; set; }
     }
 }

--- a/BO4E/COM/Angebotsteil.cs
+++ b/BO4E/COM/Angebotsteil.cs
@@ -50,7 +50,7 @@ namespace BO4E.COM
         [JsonPropertyName("positionen")]
         [ProtoMember(7)]
         public List<Angebotsposition> Positionen { get; set; }
-        
+
         /// <summary>Hier kann der Belieferungszeitraum angegeben werden, für den dieser Angebotsteil gilt. Details <see cref="Zeitraum" /></summary>
         [JsonProperty(PropertyName = "lieferzeitraum", Required = Required.Default)]
         [JsonPropertyName("lieferzeitraum")]

--- a/BO4E/COM/Angebotsteil.cs
+++ b/BO4E/COM/Angebotsteil.cs
@@ -55,6 +55,6 @@ namespace BO4E.COM
         [JsonProperty(PropertyName = "lieferzeitraum", Required = Required.Default)]
         [JsonPropertyName("lieferzeitraum")]
         [ProtoMember(8)]
-        public Zeitraum? Lieferzeitraum { get; set; }
+        public Zeitraum Lieferzeitraum { get; set; }
     }
 }

--- a/BO4E/COM/Angebotsteil.cs
+++ b/BO4E/COM/Angebotsteil.cs
@@ -50,5 +50,11 @@ namespace BO4E.COM
         [JsonPropertyName("positionen")]
         [ProtoMember(7)]
         public List<Angebotsposition> Positionen { get; set; }
+        
+        /// <summary>Hier kann der Belieferungszeitraum angegeben werden, für den dieser Angebotsteil gilt. Details <see cref="Zeitraum" /></summary>
+        [JsonProperty(PropertyName = "lieferzeitraum", Required = Required.Default)]
+        [JsonPropertyName("lieferzeitraum")]
+        [ProtoMember(8)]
+        public Zeitraum Lieferzeitraum { get; set; }
     }
 }

--- a/BO4E/protobuf-files/bo4e.proto
+++ b/BO4E/protobuf-files/bo4e.proto
@@ -69,6 +69,7 @@ message Angebotsteil {
    Menge Gesamtmengeangebotsteil = 5;
    Betrag Gesamtkostenangebotsteil = 6;
    repeated Angebotsposition Positionen = 7;
+   Zeitraum Lieferzeitraum = 8;
 }
 message Angebotsvariante {
    option (.protobuf_net.msgopt).namespace = "BO4E.COM";


### PR DESCRIPTION
There is a [version 2.0](https://www.bo4e.de/dokumentation/komponenten/com-angebotsteil/1-12-2021) for the COM Angebotsteil which now includes a Lieferzeitraum