### PR TITLE
TST-1336: Expand COM Lastprofil and COM Tagesparameter

### DIFF
--- a/BO4E/BO4Enet.xml
+++ b/BO4E/BO4Enet.xml
@@ -2913,6 +2913,18 @@
             Klimazone / Temperaturmessstelle
             </summary>
         </member>
+        <member name="P:BO4E.COM.Lastprofil.Profilart">
+            <summary>
+               Profilart des Lastprofils
+            </summary>
+            <example>ART_STANDARDLASTPROFIL</example>
+        </member>
+        <member name="P:BO4E.COM.Lastprofil.Herausgeber">
+            <summary>
+               Herausgeber des Lastprofil-Codes
+            </summary>
+            <example>BDEW</example>
+        </member>
         <member name="T:BO4E.COM.MarktpartnerDetails">
             <summary>
                 Marktrolle

--- a/BO4E/BO4Enet.xml
+++ b/BO4E/BO4Enet.xml
@@ -3637,6 +3637,12 @@
             </summary>
             <example>ZT1</example>
         </member>
+        <member name="P:BO4E.COM.Tagesparameter.Herausgeber">
+            <summary>
+               Herausgeber des Lastprofil-Codes
+            </summary>
+            <example>BDEW</example>
+        </member>
         <member name="T:BO4E.COM.Tarifberechnungsparameter">
             <summary>In dieser Komponente sind die Berechnungsparameter für die Ermittlung der Tarifkosten zusammengefasst.</summary>
         </member>

--- a/BO4E/BO4Enet.xml
+++ b/BO4E/BO4Enet.xml
@@ -7464,6 +7464,21 @@
                 sehr hohe Priorität
             </summary>
         </member>
+        <member name="T:BO4E.ENUM.Profilart">
+            <summary>Profilart (temperaturabhängig / standardlastprofil)</summary>
+        </member>
+        <member name="F:BO4E.ENUM.Profilart.ART_STANDARDLASTPROFIL">
+            <summary>ART_STANDARDLASTPROFIL</summary>
+            <remarks>Z02</remarks>
+        </member>
+        <member name="F:BO4E.ENUM.Profilart.ART_TAGESPARAMETERABHAENGIGES_LASTPROFIL">
+            <summary>ART_TAGESPARAMETERABHAENGIGES_LASTPROFIL</summary>
+            <remarks>Z03</remarks>
+        </member>
+        <member name="F:BO4E.ENUM.Profilart.ART_LASTPROFIL">
+            <summary>ART_LASTPROFIL</summary>
+            <remarks>Z12</remarks>
+        </member>
         <member name="T:BO4E.ENUM.Profiltyp">
             <summary>Profiltyp (temperaturabhängig / standardlastprofil)</summary>
         </member>

--- a/BO4E/COM/Lastprofil.cs
+++ b/BO4E/COM/Lastprofil.cs
@@ -55,5 +55,24 @@ namespace BO4E.COM
         [NonOfficial(NonOfficialCategory.CUSTOMER_REQUIREMENTS)]
         [ProtoMember(1004)]
         public Tagesparameter? Tagesparameter { get; set; }
+
+        /// <summary>
+        ///    Profilart des Lastprofils
+        /// </summary>
+        /// <example>ART_STANDARDLASTPROFIL</example>
+        [JsonProperty(PropertyName = "profilart", Required = Required.Default)]
+        [JsonPropertyName("profilart")]
+        [ProtoMember(1005)]
+        public Profilart? Profilart { get; set; }
+
+        /// <summary>
+        ///    Herausgeber des Lastprofil-Codes
+        /// </summary>
+        /// <example>BDEW</example>
+        [JsonProperty(PropertyName = "herausgeber", Required = Required.Default)]
+        [JsonPropertyName("herausgeber")]
+        [ProtoMember(1006)]
+        public string? Herausgeber { get; set; }
+
     }
 }

--- a/BO4E/COM/Tagesparameter.cs
+++ b/BO4E/COM/Tagesparameter.cs
@@ -19,19 +19,19 @@ namespace BO4E.COM
         ///     Qualifier der Klimazone
         /// </summary>
         /// <example>7624q</example>
-        [JsonProperty(PropertyName = "klimazone", Required = Required.Always)]
+        [JsonProperty(PropertyName = "klimazone", Required = Required.Default)]
         [JsonPropertyName("klimazone")]
         [ProtoMember(3)]
-        public string Klimazone { get; set; }
+        public string? Klimazone { get; set; }
 
         /// <summary>
         ///     Qualifier der Temperaturmessstelle
         /// </summary>
         /// <example>1234x</example>
-        [JsonProperty(PropertyName = "temperaturmessstelle", Required = Required.Always)]
+        [JsonProperty(PropertyName = "temperaturmessstelle", Required = Required.Default)]
         [JsonPropertyName("temperaturmessstelle")]
         [ProtoMember(4)]
-        public string Temperaturmessstelle { get; set; }
+        public string? Temperaturmessstelle { get; set; }
 
         /// <summary>
         ///    Dienstanbieter (bei Temperaturmessstellen)

--- a/BO4E/COM/Tagesparameter.cs
+++ b/BO4E/COM/Tagesparameter.cs
@@ -41,5 +41,15 @@ namespace BO4E.COM
         [JsonPropertyName("dienstanbieter")]
         [ProtoMember(5)]
         public string? Dienstanbieter { get; set; }
+
+        /// <summary>
+        ///    Herausgeber des Lastprofil-Codes
+        /// </summary>
+        /// <example>BDEW</example>
+        [JsonProperty(PropertyName = "herausgeber", Required = Required.Default)]
+        [JsonPropertyName("herausgeber")]
+        [ProtoMember(6)]
+        public string? Herausgeber { get; set; }
+
     }
 }

--- a/BO4E/ENUM/Profilart.cs
+++ b/BO4E/ENUM/Profilart.cs
@@ -1,0 +1,21 @@
+using BO4E.meta;
+
+namespace BO4E.ENUM
+{
+    /// <summary>Profilart (temperaturabhängig / standardlastprofil)</summary>
+    [NonOfficial(NonOfficialCategory.CUSTOMER_REQUIREMENTS)]
+    public enum Profilart
+    {
+        /// <summary>ART_STANDARDLASTPROFIL</summary>
+        /// <remarks>Z02</remarks>
+        ART_STANDARDLASTPROFIL,
+
+        /// <summary>ART_TAGESPARAMETERABHAENGIGES_LASTPROFIL</summary>
+        /// <remarks>Z03</remarks>
+        ART_TAGESPARAMETERABHAENGIGES_LASTPROFIL,
+
+        /// <summary>ART_LASTPROFIL</summary>
+        /// <remarks>Z12</remarks>
+        ART_LASTPROFIL
+    }
+}


### PR DESCRIPTION
At the moment in the transformer there are properties set, that are non-existent in the BO4E package and thus handled as Userproperties. 
Also there is either a Klimazone or a Temperaturmessstelle, so they can't both be required at all times.