### PR TITLE
DEV-48114: Added Marktteilnehmer to map "Eigenschaft des Messstellenbetreiber an der Lokation" into UTILMDS in FV2404

### DIFF
--- a/BO4E/BO/Marktlokation.cs
+++ b/BO4E/BO/Marktlokation.cs
@@ -367,6 +367,17 @@ namespace BO4E.BO
         public List<Konfigurationsprodukt>? Konfigurationsprodukte { get; set; }
 
         /// <summary>
+        /// Angaben zum Marktteilnehmer
+        /// Enthält den MSB Code und die MSB Rolle.
+        /// </summary>
+        [JsonProperty(Required = Required.Default, Order = 41, PropertyName = "marktteilnehmer")]
+        [JsonPropertyName("marktteilnehmer")]
+        [ProtoMember(41)]
+        [JsonPropertyOrder(41)]
+        [NonOfficial(NonOfficialCategory.CUSTOMER_REQUIREMENTS)]
+        public Marktteilnehmer? Marktteilnehmer { get; set; }
+        
+        /// <summary>
         ///     Test if a <paramref name="id" /> is a valid Marktlokations ID.
         /// </summary>
         /// <param name="id">id to test</param>

--- a/BO4E/BO/Marktlokation.cs
+++ b/BO4E/BO/Marktlokation.cs
@@ -376,7 +376,7 @@ namespace BO4E.BO
         [JsonPropertyOrder(41)]
         [NonOfficial(NonOfficialCategory.CUSTOMER_REQUIREMENTS)]
         public Marktteilnehmer? Marktteilnehmer { get; set; }
-        
+
         /// <summary>
         ///     Test if a <paramref name="id" /> is a valid Marktlokations ID.
         /// </summary>

--- a/BO4E/BO/Messlokation.cs
+++ b/BO4E/BO/Messlokation.cs
@@ -237,7 +237,7 @@ namespace BO4E.BO
 
 
         /// <summary>
-        ///     gasqualitaet für EDIFACT mapping
+        /// Gasqualitaet für EDIFACT mapping
         /// </summary>
         [JsonProperty(PropertyName = "betriebszustand", Required = Required.Default, Order = 29,
             NullValueHandling = NullValueHandling.Ignore)]
@@ -248,7 +248,7 @@ namespace BO4E.BO
         public Betriebszustand? Betriebszustand { get; set; }
 
         /// <summary>
-        ///   Zugeordnete Messprodukte
+        /// Zugeordnete Messprodukte
         /// </summary>        
         [JsonProperty(Required = Required.Default, Order = 30, PropertyName = "messprodukte")]
         [JsonPropertyName("messprodukte")]
@@ -257,6 +257,17 @@ namespace BO4E.BO
         [NonOfficial(NonOfficialCategory.CUSTOMER_REQUIREMENTS)]
         public List<Messprodukt>? Messprodukte { get; set; }
 
+        /// <summary>
+        /// Angaben zum Marktteilnehmer
+        /// Enthält den MSB Code und die MSB Rolle.
+        /// </summary>
+        [JsonProperty(Required = Required.Default, Order = 31, PropertyName = "marktteilnehmer")]
+        [JsonPropertyName("marktteilnehmer")]
+        [ProtoMember(1025)]
+        [JsonPropertyOrder(31)]
+        [NonOfficial(NonOfficialCategory.CUSTOMER_REQUIREMENTS)]
+        public Marktteilnehmer? Marktteilnehmer { get; set; }
+        
         /// <summary>
         ///     Test if a <paramref name="id" /> is a valid messlokations ID.
         /// </summary>

--- a/BO4E/BO/Messlokation.cs
+++ b/BO4E/BO/Messlokation.cs
@@ -267,7 +267,7 @@ namespace BO4E.BO
         [JsonPropertyOrder(31)]
         [NonOfficial(NonOfficialCategory.CUSTOMER_REQUIREMENTS)]
         public Marktteilnehmer? Marktteilnehmer { get; set; }
-        
+
         /// <summary>
         ///     Test if a <paramref name="id" /> is a valid messlokations ID.
         /// </summary>

--- a/BO4E/BO/Netzlokation.cs
+++ b/BO4E/BO/Netzlokation.cs
@@ -57,6 +57,7 @@ namespace BO4E.BO
         [JsonPropertyOrder(13)]
         [JsonPropertyName("grundzustaendigerMSBCodeNr")]
         [ProtoMember(7)]
+        [Obsolete("Should be placed in field Marktteilnehmer.")]
         public string? GrundzustaendigerMSBCodeNr { get; set; }
 
         /// <summary>
@@ -96,5 +97,16 @@ namespace BO4E.BO
         [JsonPropertyOrder(17)]
         [NonOfficial(NonOfficialCategory.CUSTOMER_REQUIREMENTS)]
         public List<Konfigurationsprodukt>? Konfigurationsprodukte { get; set; }
+        
+        /// <summary>
+        /// Angaben zum Marktteilnehmer
+        /// Enthält den MSB Code und die MSB Rolle.
+        /// </summary>
+        [JsonProperty(Required = Required.Default, Order = 18, PropertyName = "marktteilnehmer")]
+        [JsonPropertyName("marktteilnehmer")]
+        [ProtoMember(12)]
+        [JsonPropertyOrder(18)]
+        [NonOfficial(NonOfficialCategory.CUSTOMER_REQUIREMENTS)]
+        public Marktteilnehmer? Marktteilnehmer { get; set; }
     }
 }

--- a/BO4E/BO/Netzlokation.cs
+++ b/BO4E/BO/Netzlokation.cs
@@ -97,7 +97,7 @@ namespace BO4E.BO
         [JsonPropertyOrder(17)]
         [NonOfficial(NonOfficialCategory.CUSTOMER_REQUIREMENTS)]
         public List<Konfigurationsprodukt>? Konfigurationsprodukte { get; set; }
-        
+
         /// <summary>
         /// Angaben zum Marktteilnehmer
         /// Enthält den MSB Code und die MSB Rolle.

--- a/BO4E/BO/SteuerbareRessource.cs
+++ b/BO4E/BO/SteuerbareRessource.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text.Json.Serialization;
@@ -50,9 +51,11 @@ namespace BO4E.BO
         [JsonProperty(Required = Required.Default, Order = 12, PropertyName = "zugeordnetMSBCodeNr")]
         [JsonPropertyOrder(12)]
         [JsonPropertyName("zugeordnetMSBCodeNr")]
+        [NonOfficial(NonOfficialCategory.CUSTOMER_REQUIREMENTS)]
         [ProtoMember(12)]
+        [Obsolete("Should be placed in field Marktteilnehmer.")]
         public string? ZugeordnetMSBCodeNr { get; set; }
-
+        
         /// <summary>
         /// Produkt-Daten der Steuerbaren Ressource
         /// </summary>        
@@ -62,5 +65,16 @@ namespace BO4E.BO
         [JsonPropertyOrder(13)]
         [NonOfficial(NonOfficialCategory.CUSTOMER_REQUIREMENTS)]
         public List<Konfigurationsprodukt>? Konfigurationsprodukte { get; set; }
+        
+        /// <summary>
+        /// Angaben zum Marktteilnehmer
+        /// Enthält den MSB Code und die MSB Rolle.
+        /// </summary>
+        [JsonProperty(Required = Required.Default, Order = 14, PropertyName = "marktteilnehmer")]
+        [JsonPropertyName("marktteilnehmer")]
+        [ProtoMember(14)]
+        [JsonPropertyOrder(14)]
+        [NonOfficial(NonOfficialCategory.CUSTOMER_REQUIREMENTS)]
+        public Marktteilnehmer? Marktteilnehmer { get; set; }
     }
 }

--- a/BO4E/BO/SteuerbareRessource.cs
+++ b/BO4E/BO/SteuerbareRessource.cs
@@ -55,7 +55,7 @@ namespace BO4E.BO
         [ProtoMember(12)]
         [Obsolete("Should be placed in field Marktteilnehmer.")]
         public string? ZugeordnetMSBCodeNr { get; set; }
-        
+
         /// <summary>
         /// Produkt-Daten der Steuerbaren Ressource
         /// </summary>        
@@ -65,7 +65,7 @@ namespace BO4E.BO
         [JsonPropertyOrder(13)]
         [NonOfficial(NonOfficialCategory.CUSTOMER_REQUIREMENTS)]
         public List<Konfigurationsprodukt>? Konfigurationsprodukte { get; set; }
-        
+
         /// <summary>
         /// Angaben zum Marktteilnehmer
         /// Enthält den MSB Code und die MSB Rolle.

--- a/BO4E/ENUM/Marktrolle.cs
+++ b/BO4E/ENUM/Marktrolle.cs
@@ -5,65 +5,100 @@ namespace BO4E.ENUM
     /// <summary>Diese Rollen kann ein Marktteilnehmer einnehmen.</summary>
     public enum Marktrolle
     {
-        /// <summary>Netzbetreiber</summary>
+        /// <summary>
+        /// Netzbetreiber
+        /// </summary>
         [EnumMember(Value = "NB")]
         NB,
 
-        /// <summary>Lieferant</summary>
+        /// <summary>
+        /// Lieferant
+        /// </summary>
         [EnumMember(Value = "LF")]
         LF,
 
-        /// <summary>Messstellenbetreiber</summary>
+        /// <summary>
+        /// Messstellenbetreiber (Wettbewerblich)
+        /// </summary>
         [EnumMember(Value = "MSB")]
         MSB,
 
-        /// <summary>Messdienstleister</summary>
+        /// <summary>
+        /// Messdienstleister
+        /// </summary>
         [EnumMember(Value = "MDL")]
         MDL,
 
-        /// <summary>Dienstleister</summary>
+        /// <summary>
+        /// Dienstleister
+        /// </summary>
         [EnumMember(Value = "DL")]
         DL,
 
-        /// <summary>Bilanzkreisverantwortlicher</summary>
+        /// <summary>
+        /// Bilanzkreisverantwortlicher
+        /// </summary>
         [EnumMember(Value = "BKV")]
         BKV,
 
-        /// <summary>Bilanzkoordinator/Marktgebietsverantwortlicher</summary>
+        /// <summary>
+        /// Bilanzkoordinator/Marktgebietsverantwortlicher
+        /// </summary>
         [EnumMember(Value = "BIKO")]
         BIKO,
 
-        /// <summary>Übertragungsnetzbetreiber</summary>
+        /// <summary>
+        /// Übertragungsnetzbetreiber
+        /// </summary>
         [EnumMember(Value = "UENB")]
         UENB,
 
-        /// <summary>Kunden die NN-Entgelte selbst zahlen</summary>
+        /// <summary>
+        /// Kunden die NN-Entgelte selbst zahlen
+        /// </summary>
         [EnumMember(Value = "KUNDE_SELBST_NN")]
         KUNDE_SELBST_NN,
 
-        /// <summary>Marktgebietsverantwortlicher</summary>
+        /// <summary>
+        /// Marktgebietsverantwortlicher
+        /// </summary>
         [EnumMember(Value = "MGV")]
         MGV,
 
-        /// <summary>Einsatzverantwortlicher</summary>
+        /// <summary>
+        /// Einsatzverantwortlicher
+        /// </summary>
         [EnumMember(Value = "EIV")]
         EIV,
 
-        /// <summary>Registerbetreiber</summary>
+        /// <summary>
+        /// Registerbetreiber
+        /// </summary>
         [EnumMember(Value = "RB")]
         RB,
 
-        /// <summary>Kunde</summary>
+        /// <summary>
+        /// Kunde
+        /// </summary>
         [EnumMember(Value = "KUNDE")]
         KUNDE,
 
-        /// <summary>Interessent</summary>
+        /// <summary>
+        /// Interessent
+        /// </summary>
         [EnumMember(Value = "INTERESSENT")]
         INTERESSENT,
+        
         /// <summary>
-        /// grundzuständiger MSB
+        /// Grundzuständiger Messstellenbetreiber
         /// </summary>
         [EnumMember(Value = "GMSB")]
         GMSB,
+        
+        /// <summary>
+        /// Auffangmessstellenbetreiber
+        /// </summary>
+        [EnumMember(Value = "AMSB")]
+        AMSB,
     }
 }

--- a/BO4E/ENUM/Marktrolle.cs
+++ b/BO4E/ENUM/Marktrolle.cs
@@ -88,13 +88,13 @@ namespace BO4E.ENUM
         /// </summary>
         [EnumMember(Value = "INTERESSENT")]
         INTERESSENT,
-        
+
         /// <summary>
         /// Grundzuständiger Messstellenbetreiber
         /// </summary>
         [EnumMember(Value = "GMSB")]
         GMSB,
-        
+
         /// <summary>
         /// Auffangmessstellenbetreiber
         /// </summary>


### PR DESCRIPTION
Adding field Markteilnehmer into Netzlokation.cs, SteuerbareRessource.cs, Marktlokation.cs and Messlokation.cs to map new flag in Z91 in FV2404.

Please evaluate these changes as this could lead to problems later on. Especially if the fields marked with obsolete really should marked obsolete.
