### PR TITLE
feat: Explicitly define STJ+Newtonsoft JsonConverters for _all_ uses of `BO4E.ENUM.Verwendungszweck` (DEV-76862/DEV-77714) (#559)

### DIFF
--- a/BO4E/ENUM/Verwendungszweck.cs
+++ b/BO4E/ENUM/Verwendungszweck.cs
@@ -1,9 +1,13 @@
-using System;
 using System.Runtime.Serialization;
+using BO4E.meta.LenientConverters;
 
 namespace BO4E.ENUM;
 
 /// <summary>Verwendungungszweck der Werte Marktlokation</summary>
+[System.Text.Json.Serialization.JsonConverter(
+    typeof(SystemTextVerwendungszweckStringEnumConverter)
+)]
+[Newtonsoft.Json.JsonConverter(typeof(NewtonsoftVerwendungszweckStringEnumConverter))]
 public enum Verwendungszweck
 {
     /// <summary>Z84: Netznutzungsabrechnung</summary>

--- a/BO4ETestProject/TestStringEnumConverter.cs
+++ b/BO4ETestProject/TestStringEnumConverter.cs
@@ -583,4 +583,55 @@ public class TestStringEnumConverter
         var reSerializedJsonString = Newtonsoft.Json.JsonConvert.SerializeObject(actual, settings);
         reSerializedJsonString.Should().Contain(expectedVerwendungszweck.ToString());
     }
+
+    public class ClassWithListOfVerwendungszweck
+    {
+        public List<Verwendungszweck>? Foo { get; set; }
+    }
+
+    [TestMethod]
+    [DataRow("MEHRMINDERMENGENABRECHNUNG", Verwendungszweck.MEHRMINDERMENGENABRECHNUNG)]
+    [DataRow("MEHRMINDERMBENGENABRECHNUNG", Verwendungszweck.MEHRMINDERMENGENABRECHNUNG)]
+    public void Test_Newtonsoft_List_of_Verwendungszweck_Conversion(
+        string? jsonValue,
+        Verwendungszweck expectedVerwendungszweck
+    )
+    {
+        var jsonString = "{\"Foo\": [\"" + jsonValue + "\"]}";
+        var result = JsonConvert.DeserializeObject<ClassWithListOfVerwendungszweck>(jsonString);
+        result.Should().NotBeNull();
+        result.Foo.Should().NotBeNullOrEmpty().And.ContainInOrder(expectedVerwendungszweck);
+    }
+
+    [TestMethod]
+    public void Test_Newtonsoft_List_of_Verwendungszweck_Conversion_With_Null()
+    {
+        var jsonString = "{\"Foo\": null}";
+        var result = JsonConvert.DeserializeObject<ClassWithListOfVerwendungszweck>(jsonString);
+        result.Should().NotBeNull();
+        result.Foo.Should().BeNull();
+    }
+
+    [TestMethod]
+    [DataRow("MEHRMINDERMENGENABRECHNUNG", Verwendungszweck.MEHRMINDERMENGENABRECHNUNG)]
+    [DataRow("MEHRMINDERMBENGENABRECHNUNG", Verwendungszweck.MEHRMINDERMENGENABRECHNUNG)]
+    public void Test_SystemText_List_of_Verwendungszweck_Conversion(
+        string? jsonValue,
+        Verwendungszweck expectedVerwendungszweck
+    )
+    {
+        var jsonString = "{\"Foo\": [\"" + jsonValue + "\"]}";
+        var result = JsonSerializer.Deserialize<ClassWithListOfVerwendungszweck>(jsonString);
+        result.Should().NotBeNull();
+        result.Foo.Should().NotBeNullOrEmpty().And.ContainInOrder(expectedVerwendungszweck);
+    }
+
+    [TestMethod]
+    public void Test_SystemText_List_of_Verwendungszweck_Conversion_With_Null()
+    {
+        var jsonString = "{\"Foo\": null}";
+        var result = JsonSerializer.Deserialize<ClassWithListOfVerwendungszweck>(jsonString);
+        result.Should().NotBeNull();
+        result.Foo.Should().BeNull();
+    }
 }


### PR DESCRIPTION
* add tests

* trocken übung

* es kann so einfach sein!

* format

* empty commit to trigger ci

---------

Co-authored-by: Konstantin <konstantin.klein+github@hochfrequenz.de>