### PR TITLE
fix: when using `SET_INITIAL_DATE_IF_NULL` in STJ only set MinValue if JSON value is null and runtime type is not nullable (#600)

### DIFF
--- a/BO4E/meta/LenientConverters/LenientSystemTextJsonDateTimeConverter.cs
+++ b/BO4E/meta/LenientConverters/LenientSystemTextJsonDateTimeConverter.cs
@@ -51,6 +51,11 @@ public class LenientSystemTextJsonDateTimeConverter : JsonConverter<DateTime>
         JsonSerializerOptions options
     )
     {
+        bool targetTypeIsNullable = Nullable.GetUnderlyingType(typeToConvert) != null;
+        if (reader.TokenType == JsonTokenType.Null && !targetTypeIsNullable)
+        {
+            return DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
+        }
         if (reader.TryGetDateTime(out var dt))
         {
             return DateTime.SpecifyKind(dt, DateTimeKind.Utc);

--- a/BO4E/meta/LenientConverters/LenientSystemTextJsonDateTimeOffsetConverter.cs
+++ b/BO4E/meta/LenientConverters/LenientSystemTextJsonDateTimeOffsetConverter.cs
@@ -55,6 +55,11 @@ public class LenientSystemTextJsonDateTimeOffsetConverter : JsonConverter<DateTi
         JsonSerializerOptions options
     )
     {
+        bool targetTypeIsNullable = Nullable.GetUnderlyingType(typeToConvert) != null;
+        if (reader.TokenType == JsonTokenType.Null && !targetTypeIsNullable)
+        {
+            return DateTimeOffset.MinValue;
+        }
         if (reader.TryGetDateTimeOffset(out var dto))
         {
             return dto;

--- a/BO4ETestProject/TestNullableDateTimeOffsetConverter.cs
+++ b/BO4ETestProject/TestNullableDateTimeOffsetConverter.cs
@@ -1,0 +1,78 @@
+using System;
+using BO4E.meta.LenientConverters;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TestBO4E;
+
+[TestClass]
+public class TestNullableDateTimeOffsetConverter
+{
+    public class ClassWithNullableDateTimeOffset
+    {
+        public DateTimeOffset? Foo { get; set; }
+    }
+
+    [TestMethod]
+    public void Test_Nullable_DateTimeOffset_is_not_set_to_min_value()
+    {
+        const string jsonString = "{\"Foo\":null}";
+        var lenientParsing = LenientParsing.SET_INITIAL_DATE_IF_NULL | LenientParsing.DATE_TIME;
+        var obj = System.Text.Json.JsonSerializer.Deserialize<ClassWithNullableDateTimeOffset>(
+            jsonString,
+            lenientParsing.GetJsonSerializerOptions()
+        );
+        obj.Foo.Should().BeNull();
+    }
+
+    public class ClassWithNonNullableDateTimeOffset
+    {
+        public DateTimeOffset Foo { get; set; }
+    }
+
+    [TestMethod]
+    public void Test_NonNullable_DateTimeOffset_is_set_to_min_value()
+    {
+        const string jsonString = "{\"Foo\":null}";
+        var lenientParsing = LenientParsing.SET_INITIAL_DATE_IF_NULL | LenientParsing.DATE_TIME;
+        var obj = System.Text.Json.JsonSerializer.Deserialize<ClassWithNonNullableDateTimeOffset>(
+            jsonString,
+            lenientParsing.GetJsonSerializerOptions()
+        );
+        obj.Foo.Should().Be(DateTimeOffset.MinValue);
+    }
+
+    public class ClassWithNullableDateTime
+    {
+        public DateTime? Foo { get; set; }
+    }
+
+    [TestMethod]
+    public void Test_Nullable_DateTime_is_not_set_to_min_value()
+    {
+        const string jsonString = "{\"Foo\":null}";
+        var lenientParsing = LenientParsing.SET_INITIAL_DATE_IF_NULL | LenientParsing.DATE_TIME;
+        var obj = System.Text.Json.JsonSerializer.Deserialize<ClassWithNullableDateTime>(
+            jsonString,
+            lenientParsing.GetJsonSerializerOptions()
+        );
+        obj.Foo.Should().BeNull();
+    }
+
+    public class ClassWithNonNullableDateTime
+    {
+        public DateTime Foo { get; set; }
+    }
+
+    [TestMethod]
+    public void Test_NonNullable_DateTime_is_set_to_min_value()
+    {
+        const string jsonString = "{\"Foo\":null}";
+        var lenientParsing = LenientParsing.SET_INITIAL_DATE_IF_NULL | LenientParsing.DATE_TIME;
+        var obj = System.Text.Json.JsonSerializer.Deserialize<ClassWithNonNullableDateTime>(
+            jsonString,
+            lenientParsing.GetJsonSerializerOptions()
+        );
+        obj.Foo.Should().Be(DateTime.MinValue);
+    }
+}


### PR DESCRIPTION
fix: when using `SET_INITIAL_DATE_IF_NULL` in STJ only set MinValue if json value is not nullable

i think, this was the initial intention behind the converters? and there's no older/existing test that fails, so I think it's fine that way

note that this does _NOT_ change the behaviour of the newtonsoft converters!

Co-authored-by: Konstantin <konstantin.klein+github@hochfrequenz.de>