### PR TITLE
Revert "Add Additional Information field (#608)"

### DIFF
--- a/BO4E/Marktkommunikation/ZeitabhaengigeBeziehung.cs
+++ b/BO4E/Marktkommunikation/ZeitabhaengigeBeziehung.cs
@@ -45,13 +45,4 @@ public class ZeitabhaengigeBeziehung
     [JsonPropertyOrder(4)]
     [Newtonsoft.Json.JsonProperty(PropertyName = "childId", Order = 4)]
     public string? ChildId { get; set; }
-
-    /// <summary>
-    /// An extra field to store or add additional information for further processing.
-    /// This can be used to distinguish different kinds of relations between the same parent and child type.
-    /// </summary>
-    [JsonPropertyName("additionalInformation")]
-    [JsonPropertyOrder(5)]
-    [Newtonsoft.Json.JsonProperty(PropertyName = "additionalInformation", Order = 5)]
-    public string? AdditionalInformation { get; set; }
 }


### PR DESCRIPTION
This reverts commit 2910114cf9b0d7735cbd7541654f97a5385d62c4.
siehe: https://github.com/Hochfrequenz/BO4E-dotnet/pull/608#issuecomment-2497661600

wir wollen nichts auf vorrat behalten.