### PR TITLE
fix: Serialize Geraetemerkmal WITH `GAS_` prefix in STJ (instead of w/o)

### DIFF
--- a/BO4E/meta/LenientConverters/LenientSystemTextGeraetemerkmalGasConverter.cs
+++ b/BO4E/meta/LenientConverters/LenientSystemTextGeraetemerkmalGasConverter.cs
@@ -62,13 +62,6 @@ public class LenientSystemTextGeraetemerkmalGasConverter
     )
     {
         var stringValue = value.ToString();
-        var match = GasPrefixRegex.Match(stringValue);
-        if (!match.Success)
-        {
-            writer.WriteStringValue(stringValue);
-            return;
-        }
-        var rest = match.Groups["rest"].Value;
-        writer.WriteStringValue(rest);
+        writer.WriteStringValue(stringValue);
     }
 }

--- a/BO4ETestProject/TestGeraetemerkmalConverter.cs
+++ b/BO4ETestProject/TestGeraetemerkmalConverter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using BO4E.ENUM;
 using BO4E.meta.LenientConverters;
@@ -86,6 +87,27 @@ public class TestGeraeteerkmalDeserialization
     }
 
     [TestMethod]
+    public void TestNewtonsoft_Success_Nullable_Serialization()
+    {
+        var myInstance = new SomethingWithANullableGeraetemerkmal()
+        {
+            Merkmal = Geraetemerkmal.GAS_G4,
+        };
+        var result = JsonConvert.SerializeObject(
+            myInstance,
+            new JsonSerializerSettings()
+            {
+                Converters = new List<Newtonsoft.Json.JsonConverter>()
+                {
+                    new Newtonsoft.Json.Converters.StringEnumConverter(),
+                    new LenientGeraetemerkmalGasConverter(),
+                },
+            }
+        );
+        result.Should().NotBeNullOrWhiteSpace().And.Contain("\"GAS_G4\"").And.NotContain("\"G4\"");
+    }
+
+    [TestMethod]
     public void TestNewtonsoft_Success_Nullable_WASSER_MWZW()
     {
         var result =
@@ -119,6 +141,21 @@ public class TestGeraeteerkmalDeserialization
             settings
         );
         result.Merkmal.Should().Be(Geraetemerkmal.GAS_G4);
+    }
+
+    [TestMethod]
+    public void TestSystemText_Success_NonNullable_Serialization()
+    {
+        var myInstance = new SomethingWithANullableGeraetemerkmal()
+        {
+            Merkmal = Geraetemerkmal.GAS_G4,
+        };
+        var settings = new System.Text.Json.JsonSerializerOptions()
+        {
+            Converters = { new LenientSystemTextGeraetemerkmalGasConverter() },
+        };
+        var result = System.Text.Json.JsonSerializer.Serialize(myInstance, settings);
+        result.Should().NotBeNullOrWhiteSpace().And.Contain("\"GAS_G4\"").And.NotContain("\"G4\"");
     }
 
     [TestMethod]
@@ -213,7 +250,7 @@ public class TestGeraeteerkmalDeserialization
         };
         var instance = new SomethingWithAGeraetemerkmal { Merkmal = Geraetemerkmal.GAS_G4 };
         var json = System.Text.Json.JsonSerializer.Serialize(instance, settings);
-        json.Should().Be("{\"merkmal\":\"G4\"}");
+        json.Should().Be($"{{\"merkmal\":\"{Geraetemerkmal.GAS_G4.ToString()}\"}}");
     }
 
     [TestMethod]


### PR DESCRIPTION
newtonsoft has always been ok, because: https://github.com/Hochfrequenz/BO4E-dotnet/blob/d7d4a661a67b3887b89c0701ba32b3ed2ea25332/BO4E/meta/LenientConverters/LenientGeraetemerkmalGasConverter.cs#L15
