### PR TITLE
Handle object-shaped Marktteilnehmerrolle values

### DIFF
--- a/BO4E/BO/Marktteilnehmer.cs
+++ b/BO4E/BO/Marktteilnehmer.cs
@@ -72,6 +72,9 @@ public class Marktteilnehmer : Geschaeftspartner
     [JsonProperty(Order = 36, PropertyName = "rolle")]
     [JsonPropertyOrder(36)]
     [JsonPropertyName("rolle")]
+    [System.Text.Json.Serialization.JsonConverter(
+        typeof(meta.LenientConverters.SystemTextNullableMarktteilnehmerrolleStringEnumConverter)
+    )]
     //[ProtoMember(24)]
     public Marktteilnehmerrolle? Rolle { get; set; }
 }

--- a/BO4E/ENUM/Marktteilnehmerrolle.cs
+++ b/BO4E/ENUM/Marktteilnehmerrolle.cs
@@ -1,4 +1,5 @@
 using System.Runtime.Serialization;
+using BO4E.meta.LenientConverters;
 using ProtoBuf;
 
 namespace BO4E.ENUM;
@@ -6,6 +7,10 @@ namespace BO4E.ENUM;
 /// <summary>
 /// Rolle eines Marktteilnehmers im Nachrichtenkontext.
 /// </summary>
+[Newtonsoft.Json.JsonConverter(typeof(NewtonsoftMarktteilnehmerrolleStringEnumConverter))]
+[System.Text.Json.Serialization.JsonConverter(
+    typeof(SystemTextMarktteilnehmerrolleStringEnumConverter)
+)]
 public enum Marktteilnehmerrolle
 {
     /// <summary>
@@ -17,7 +22,7 @@ public enum Marktteilnehmerrolle
     ANDERE_PARTEI,
 
     /// <summary>
-    /// Empfaenger einer Nachricht
+    /// Empfaenger einer NachrichUs
     /// </summary>
     [ProtoEnum(Name = nameof(Marktteilnehmerrolle) + "_" + nameof(EMPFAENGER))]
     [EnumMember(Value = "EMPFAENGER")]

--- a/BO4E/meta/LenientConverters/LenientParsingExtensionsNewtonsoft.cs
+++ b/BO4E/meta/LenientConverters/LenientParsingExtensionsNewtonsoft.cs
@@ -75,6 +75,10 @@ public static class LenientParsingExtensionsNewtonsoft
             converters.Insert(index: 0, item: new NewtonsoftGasqualitaetStringEnumConverter());
             converters.Insert(index: 0, item: new NewtonsoftVerwendungszweckStringEnumConverter());
             // need to be placed BEFORE the regular StringEnumConverter, see their documentation
+            // Note: No Marktteilnehmerrolle converter registered here. In Newtonsoft, the type-level
+            // [JsonConverter] attribute on the enum has higher priority than converters in settings,
+            // so the attribute alone is sufficient. This differs from STJ where options-level converters
+            // override type-level attributes (see LenientSystemTextJsonParsingExtensions).
         }
         var settings = new JsonSerializerSettings
         {

--- a/BO4E/meta/LenientConverters/LenientSystemTextJsonParsingExtensions.cs
+++ b/BO4E/meta/LenientConverters/LenientSystemTextJsonParsingExtensions.cs
@@ -47,6 +47,15 @@ public static class LenientSystemTextJsonParsingExtensions
         settings.Converters.Add(new SystemTextVerwendungszweckStringEnumConverter());
         settings.Converters.Add(new SystemTextNullableGasqualitaetStringEnumConverter());
         settings.Converters.Add(new SystemTextGasqualitaetStringEnumConverter());
+        // Marktteilnehmerrolle: In STJ, options-level converters override type-level [JsonConverter]
+        // attributes (priority: property attribute > options > type attribute). So the
+        // StringNullableEnumConverter/JsonStringEnumConverter below would win over the type-level
+        // attribute. We must register these explicitly here to handle any class with a
+        // Marktteilnehmerrolle property. Marktteilnehmer.Rolle also has a property-level attribute
+        // as belt-and-suspenders. For Newtonsoft, the type-level [JsonConverter] has highest priority,
+        // so no registration is needed there (see LenientParsingExtensionsNewtonsoft).
+        settings.Converters.Add(new SystemTextNullableMarktteilnehmerrolleStringEnumConverter());
+        settings.Converters.Add(new SystemTextMarktteilnehmerrolleStringEnumConverter());
         settings.Converters.Add(new LenientSystemTextJsonStringToBoolConverter());
         settings.Converters.Add(new StringNullableEnumConverter());
         settings.Converters.Add(new JsonStringEnumConverter());

--- a/BO4E/meta/LenientConverters/NewtonsoftMarktteilnehmerrolleStringEnumConverter.cs
+++ b/BO4E/meta/LenientConverters/NewtonsoftMarktteilnehmerrolleStringEnumConverter.cs
@@ -1,0 +1,77 @@
+using System;
+using BO4E.ENUM;
+
+namespace BO4E.meta.LenientConverters;
+
+/// <summary>
+/// Converts legacy value 'anderepartei' to Enum Member Marktteilnehmerrolle.ANDERE_PARTEI
+/// </summary>
+/// <remarks>
+/// It is intended, that you use this converter TOGETHER with the <see cref="Newtonsoft.Json.Converters.StringEnumConverter"/>.
+/// In this case you need to add this converter BEFORE the <see cref="Newtonsoft.Json.Converters.StringEnumConverter"/> in the list of converters.
+/// <code>
+/// var settings = new Newtonsoft.Json.JsonSerializerSettings()
+/// {
+///     Converters = { new NewtonsoftMarktteilnehmerrolleStringEnumConverter(), new StringEnumConverter() }
+/// };
+/// </code>
+/// </remarks>
+public class NewtonsoftMarktteilnehmerrolleStringEnumConverter
+    : Newtonsoft.Json.JsonConverter<Marktteilnehmerrolle?>
+{
+    /// <inheritdoc />
+    public override Marktteilnehmerrolle? ReadJson(
+        Newtonsoft.Json.JsonReader reader,
+        Type objectType,
+        Marktteilnehmerrolle? existingValue,
+        bool hasExistingValue,
+        Newtonsoft.Json.JsonSerializer serializer
+    )
+    {
+        if (reader.TokenType == Newtonsoft.Json.JsonToken.Null)
+        {
+            return null;
+        }
+        if (reader.TokenType == Newtonsoft.Json.JsonToken.Integer)
+        {
+            var integerValue = Convert.ToInt64(reader.Value);
+            return (Marktteilnehmerrolle)Enum.ToObject(typeof(Marktteilnehmerrolle), integerValue);
+        }
+        if (reader.TokenType == Newtonsoft.Json.JsonToken.String)
+        {
+            string? enumString = reader.Value?.ToString();
+
+            return enumString?.ToUpper() switch
+            {
+                "ANDEREPARTEI" => Marktteilnehmerrolle.ANDERE_PARTEI,
+                _ => Enum.TryParse(enumString?.ToUpper(), out Marktteilnehmerrolle result)
+                    ? result
+                    : throw new Newtonsoft.Json.JsonSerializationException(
+                        $"Invalid value for {objectType}: {enumString}"
+                    ),
+            };
+        }
+
+        throw new Newtonsoft.Json.JsonSerializationException("Expected string value.");
+    }
+
+    /// <inheritdoc />
+    public override void WriteJson(
+        Newtonsoft.Json.JsonWriter writer,
+        Marktteilnehmerrolle? value,
+        Newtonsoft.Json.JsonSerializer serializer
+    )
+    {
+        if (value is null)
+        {
+            writer.WriteNull();
+        }
+        else
+        {
+            writer.WriteValue(value.ToString());
+        }
+    }
+
+    /// <inheritdoc />
+    public override bool CanWrite => true;
+}

--- a/BO4E/meta/LenientConverters/NewtonsoftMarktteilnehmerrolleStringEnumConverter.cs
+++ b/BO4E/meta/LenientConverters/NewtonsoftMarktteilnehmerrolleStringEnumConverter.cs
@@ -4,17 +4,15 @@ using BO4E.ENUM;
 namespace BO4E.meta.LenientConverters;
 
 /// <summary>
-/// Converts legacy value 'anderepartei' to Enum Member Marktteilnehmerrolle.ANDERE_PARTEI
+/// Converts legacy value 'anderepartei' to Enum Member Marktteilnehmerrolle.ANDERE_PARTEI.
 /// </summary>
 /// <remarks>
-/// It is intended, that you use this converter TOGETHER with the <see cref="Newtonsoft.Json.Converters.StringEnumConverter"/>.
-/// In this case you need to add this converter BEFORE the <see cref="Newtonsoft.Json.Converters.StringEnumConverter"/> in the list of converters.
-/// <code>
-/// var settings = new Newtonsoft.Json.JsonSerializerSettings()
-/// {
-///     Converters = { new NewtonsoftMarktteilnehmerrolleStringEnumConverter(), new StringEnumConverter() }
-/// };
-/// </code>
+/// This converter is applied via the type-level <c>[JsonConverter]</c> attribute on <see cref="Marktteilnehmerrolle"/>.
+/// In Newtonsoft.Json, type-level attributes have higher priority than converters in
+/// <see cref="Newtonsoft.Json.JsonSerializerSettings.Converters"/>, so explicit registration is not needed.
+/// <para/>
+/// Note: <see cref="WriteJson"/> uses <c>value.ToString()</c> which returns the C# member name (e.g. "ANDERE_PARTEI").
+/// This only produces correct output because the member name matches the <c>[EnumMember]</c> value.
 /// </remarks>
 public class NewtonsoftMarktteilnehmerrolleStringEnumConverter
     : Newtonsoft.Json.JsonConverter<Marktteilnehmerrolle?>

--- a/BO4E/meta/LenientConverters/SystemTextMarktteilnehmerrolleStringEnumConverter.cs
+++ b/BO4E/meta/LenientConverters/SystemTextMarktteilnehmerrolleStringEnumConverter.cs
@@ -7,6 +7,10 @@ namespace BO4E.meta.LenientConverters;
 /// Converts legacy value 'anderepartei' to Enum Member Marktteilnehmerrolle.ANDERE_PARTEI for non-nullable Marktteilnehmerrolle.
 /// <seealso cref="SystemTextNullableMarktteilnehmerrolleStringEnumConverter"/>
 /// </summary>
+/// <remarks>
+/// Note: <see cref="Write"/> uses <c>value.ToString()</c> which returns the C# member name (e.g. "ANDERE_PARTEI").
+/// This only produces correct output because the member name matches the <c>[EnumMember]</c> value.
+/// </remarks>
 public class SystemTextMarktteilnehmerrolleStringEnumConverter
     : System.Text.Json.Serialization.JsonConverter<Marktteilnehmerrolle>
 {

--- a/BO4E/meta/LenientConverters/SystemTextMarktteilnehmerrolleStringEnumConverter.cs
+++ b/BO4E/meta/LenientConverters/SystemTextMarktteilnehmerrolleStringEnumConverter.cs
@@ -1,0 +1,47 @@
+using System;
+using BO4E.ENUM;
+
+namespace BO4E.meta.LenientConverters;
+
+/// <summary>
+/// Converts legacy value 'anderepartei' to Enum Member Marktteilnehmerrolle.ANDERE_PARTEI for non-nullable Marktteilnehmerrolle.
+/// <seealso cref="SystemTextNullableMarktteilnehmerrolleStringEnumConverter"/>
+/// </summary>
+public class SystemTextMarktteilnehmerrolleStringEnumConverter
+    : System.Text.Json.Serialization.JsonConverter<Marktteilnehmerrolle>
+{
+    /// <inheritdoc />
+    public override Marktteilnehmerrolle Read(
+        ref System.Text.Json.Utf8JsonReader reader,
+        Type typeToConvert,
+        System.Text.Json.JsonSerializerOptions options
+    )
+    {
+        if (reader.TokenType == System.Text.Json.JsonTokenType.Number)
+        {
+            var integerValue = reader.GetInt64();
+            return (Marktteilnehmerrolle)Enum.ToObject(typeof(Marktteilnehmerrolle), integerValue);
+        }
+        string? enumString = reader.GetString();
+
+        return enumString?.ToUpper() switch
+        {
+            "ANDEREPARTEI" => Marktteilnehmerrolle.ANDERE_PARTEI,
+            _ => Enum.TryParse(enumString?.ToUpper(), out Marktteilnehmerrolle result)
+                ? result
+                : throw new System.Text.Json.JsonException(
+                    $"Invalid value for {typeToConvert}: {enumString}"
+                ),
+        };
+    }
+
+    /// <inheritdoc />
+    public override void Write(
+        System.Text.Json.Utf8JsonWriter writer,
+        Marktteilnehmerrolle value,
+        System.Text.Json.JsonSerializerOptions options
+    )
+    {
+        writer.WriteStringValue(value.ToString());
+    }
+}

--- a/BO4E/meta/LenientConverters/SystemTextNullableMarktteilnehmerrolleStringEnumConverter.cs
+++ b/BO4E/meta/LenientConverters/SystemTextNullableMarktteilnehmerrolleStringEnumConverter.cs
@@ -1,0 +1,58 @@
+using System;
+using BO4E.ENUM;
+
+namespace BO4E.meta.LenientConverters;
+
+/// <summary>
+/// Converts legacy value 'anderepartei' to Enum Member Marktteilnehmerrolle.ANDERE_PARTEI.
+/// For non-nullable see <seealso cref="SystemTextMarktteilnehmerrolleStringEnumConverter"/>.
+/// </summary>
+public class SystemTextNullableMarktteilnehmerrolleStringEnumConverter
+    : System.Text.Json.Serialization.JsonConverter<Marktteilnehmerrolle?>
+{
+    /// <inheritdoc />
+    public override Marktteilnehmerrolle? Read(
+        ref System.Text.Json.Utf8JsonReader reader,
+        Type typeToConvert,
+        System.Text.Json.JsonSerializerOptions options
+    )
+    {
+        if (reader.TokenType == System.Text.Json.JsonTokenType.Null)
+        {
+            return null;
+        }
+        if (reader.TokenType == System.Text.Json.JsonTokenType.Number)
+        {
+            var integerValue = reader.GetInt64();
+            return (Marktteilnehmerrolle)Enum.ToObject(typeof(Marktteilnehmerrolle), integerValue);
+        }
+        string? enumString = reader.GetString();
+
+        return enumString?.ToUpper() switch
+        {
+            "ANDEREPARTEI" => Marktteilnehmerrolle.ANDERE_PARTEI,
+            _ => Enum.TryParse(enumString?.ToUpper(), out Marktteilnehmerrolle result)
+                ? result
+                : throw new System.Text.Json.JsonException(
+                    $"Invalid value for {typeToConvert}: {enumString}"
+                ),
+        };
+    }
+
+    /// <inheritdoc />
+    public override void Write(
+        System.Text.Json.Utf8JsonWriter writer,
+        Marktteilnehmerrolle? value,
+        System.Text.Json.JsonSerializerOptions options
+    )
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+        }
+        else
+        {
+            writer.WriteStringValue(value.ToString());
+        }
+    }
+}

--- a/BO4E/meta/LenientConverters/SystemTextNullableMarktteilnehmerrolleStringEnumConverter.cs
+++ b/BO4E/meta/LenientConverters/SystemTextNullableMarktteilnehmerrolleStringEnumConverter.cs
@@ -7,6 +7,10 @@ namespace BO4E.meta.LenientConverters;
 /// Converts legacy value 'anderepartei' to Enum Member Marktteilnehmerrolle.ANDERE_PARTEI.
 /// For non-nullable see <seealso cref="SystemTextMarktteilnehmerrolleStringEnumConverter"/>.
 /// </summary>
+/// <remarks>
+/// Note: <see cref="Write"/> uses <c>value.ToString()</c> which returns the C# member name (e.g. "ANDERE_PARTEI").
+/// This only produces correct output because the member name matches the <c>[EnumMember]</c> value.
+/// </remarks>
 public class SystemTextNullableMarktteilnehmerrolleStringEnumConverter
     : System.Text.Json.Serialization.JsonConverter<Marktteilnehmerrolle?>
 {

--- a/BO4E/meta/LenientConverters/SystemTextNullableMarktteilnehmerrolleStringEnumConverter.cs
+++ b/BO4E/meta/LenientConverters/SystemTextNullableMarktteilnehmerrolleStringEnumConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json;
 using BO4E.ENUM;
 
 namespace BO4E.meta.LenientConverters;
@@ -14,6 +15,8 @@ namespace BO4E.meta.LenientConverters;
 public class SystemTextNullableMarktteilnehmerrolleStringEnumConverter
     : System.Text.Json.Serialization.JsonConverter<Marktteilnehmerrolle?>
 {
+    private static readonly string[] LegacyObjectPropertyNames = ["code", "name", "value", "wert"];
+
     /// <inheritdoc />
     public override Marktteilnehmerrolle? Read(
         ref System.Text.Json.Utf8JsonReader reader,
@@ -30,17 +33,82 @@ public class SystemTextNullableMarktteilnehmerrolleStringEnumConverter
             var integerValue = reader.GetInt64();
             return (Marktteilnehmerrolle)Enum.ToObject(typeof(Marktteilnehmerrolle), integerValue);
         }
+        if (reader.TokenType == System.Text.Json.JsonTokenType.StartObject)
+        {
+            using var document = JsonDocument.ParseValue(ref reader);
+            return ParseLegacyObject(document.RootElement, typeToConvert);
+        }
         string? enumString = reader.GetString();
 
-        return enumString?.ToUpper() switch
+        return ParseString(enumString, typeToConvert);
+    }
+
+    private static Marktteilnehmerrolle? ParseLegacyObject(
+        JsonElement rolleObject,
+        Type typeToConvert
+    )
+    {
+        foreach (var propertyName in LegacyObjectPropertyNames)
         {
-            "ANDEREPARTEI" => Marktteilnehmerrolle.ANDERE_PARTEI,
-            _ => Enum.TryParse(enumString?.ToUpper(), out Marktteilnehmerrolle result)
+            if (
+                rolleObject.TryGetProperty(propertyName, out var property)
+                && TryParseProperty(property, typeToConvert, out var parsed)
+            )
+            {
+                return parsed;
+            }
+        }
+
+        foreach (var property in rolleObject.EnumerateObject())
+        {
+            if (TryParseProperty(property.Value, typeToConvert, out var parsed))
+            {
+                return parsed;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryParseProperty(
+        JsonElement property,
+        Type typeToConvert,
+        out Marktteilnehmerrolle? parsed
+    )
+    {
+        parsed = property.ValueKind switch
+        {
+            JsonValueKind.String => TryParseString(property.GetString(), out var result)
                 ? result
-                : throw new System.Text.Json.JsonException(
-                    $"Invalid value for {typeToConvert}: {enumString}"
-                ),
+                : null,
+            JsonValueKind.Number when property.TryGetInt64(out var integerValue) =>
+                (Marktteilnehmerrolle)Enum.ToObject(typeof(Marktteilnehmerrolle), integerValue),
+            JsonValueKind.Null => null,
+            _ => null,
         };
+
+        return parsed is not null;
+    }
+
+    private static Marktteilnehmerrolle ParseString(string? enumString, Type typeToConvert)
+    {
+        return TryParseString(enumString, out var result)
+            ? result
+            : throw new System.Text.Json.JsonException(
+                $"Invalid value for {typeToConvert}: {enumString}"
+            );
+    }
+
+    private static bool TryParseString(string? enumString, out Marktteilnehmerrolle result)
+    {
+        var normalized = enumString?.ToUpper();
+        if (normalized == "ANDEREPARTEI")
+        {
+            result = Marktteilnehmerrolle.ANDERE_PARTEI;
+            return true;
+        }
+
+        return Enum.TryParse(normalized, out result);
     }
 
     /// <inheritdoc />

--- a/BO4ETestProject/TestStringEnumConverter.cs
+++ b/BO4ETestProject/TestStringEnumConverter.cs
@@ -1008,4 +1008,128 @@ public class TestStringEnumConverter
         actual.Should().NotBeNull();
         actual.Rolle.Should().Be(expectedRolle);
     }
+
+    [TestMethod]
+    [DataRow("anderepartei", Marktteilnehmerrolle.ANDERE_PARTEI)]
+    [DataRow("ANDERE_PARTEI", Marktteilnehmerrolle.ANDERE_PARTEI)]
+    [DataRow("EMPFAENGER", Marktteilnehmerrolle.EMPFAENGER)]
+    public void Test_Newtonsoft_Marktteilnehmerrolle_Default_Settings(
+        string jsonValue,
+        Marktteilnehmerrolle expectedRolle
+    )
+    {
+        // Proves that the type-level [JsonConverter] attribute works without any explicit
+        // converter registration — this is the core design assumption for Newtonsoft.
+        var jsonString = "{\"Foo\": \"" + jsonValue + "\"}";
+        var actual =
+            Newtonsoft.Json.JsonConvert.DeserializeObject<ClassWithNullableMarktteilnehmerrolle>(
+                jsonString
+            );
+        actual.Should().NotBeNull();
+        actual.Foo.Should().Be(expectedRolle);
+    }
+
+    [TestMethod]
+    [DataRow("anderepartei", Marktteilnehmerrolle.ANDERE_PARTEI)]
+    [DataRow("ANDERE_PARTEI", Marktteilnehmerrolle.ANDERE_PARTEI)]
+    [DataRow("EMPFAENGER", Marktteilnehmerrolle.EMPFAENGER)]
+    public void Test_SystemText_Marktteilnehmerrolle_Default_Settings_Non_Nullable(
+        string jsonValue,
+        Marktteilnehmerrolle expectedRolle
+    )
+    {
+        // Proves that the type-level [JsonConverter] attribute works without any explicit
+        // converter registration for non-nullable properties.
+        var jsonString = "{\"Foo\": \"" + jsonValue + "\"}";
+        var actual =
+            System.Text.Json.JsonSerializer.Deserialize<ClassWithNonNullableMarktteilnehmerrolle>(
+                jsonString
+            );
+        actual.Should().NotBeNull();
+        actual.Foo.Should().Be(expectedRolle);
+    }
+
+    [TestMethod]
+    [DataRow((int)Marktteilnehmerrolle.ANDERE_PARTEI, Marktteilnehmerrolle.ANDERE_PARTEI)]
+    [DataRow((int)Marktteilnehmerrolle.EMPFAENGER, Marktteilnehmerrolle.EMPFAENGER)]
+    public void Test_SystemText_Marktteilnehmerrolle_Integer_Deserialization(
+        int jsonValue,
+        Marktteilnehmerrolle expectedRolle
+    )
+    {
+        string jsonString = "{\"Foo\": " + jsonValue + "}";
+        var settings = new JsonSerializerOptions
+        {
+            Converters = { new SystemTextMarktteilnehmerrolleStringEnumConverter() },
+        };
+        var actual =
+            System.Text.Json.JsonSerializer.Deserialize<ClassWithNonNullableMarktteilnehmerrolle>(
+                jsonString,
+                settings
+            );
+        actual.Should().NotBeNull();
+        actual.Foo.Should().Be(expectedRolle);
+    }
+
+    [TestMethod]
+    [DataRow((int)Marktteilnehmerrolle.ANDERE_PARTEI, Marktteilnehmerrolle.ANDERE_PARTEI)]
+    [DataRow((int)Marktteilnehmerrolle.EMPFAENGER, Marktteilnehmerrolle.EMPFAENGER)]
+    public void Test_Newtonsoft_Marktteilnehmerrolle_Integer_Deserialization(
+        int jsonValue,
+        Marktteilnehmerrolle expectedRolle
+    )
+    {
+        string jsonString = "{\"Foo\": " + jsonValue + "}";
+        var settings = new Newtonsoft.Json.JsonSerializerSettings()
+        {
+            Converters =
+            {
+                new NewtonsoftMarktteilnehmerrolleStringEnumConverter(),
+                new StringEnumConverter(),
+            },
+        };
+        var actual =
+            Newtonsoft.Json.JsonConvert.DeserializeObject<ClassWithNonNullableMarktteilnehmerrolle>(
+                jsonString,
+                settings
+            );
+        actual.Should().NotBeNull();
+        actual.Foo.Should().Be(expectedRolle);
+    }
+
+    [TestMethod]
+    public void Test_Newtonsoft_Marktteilnehmerrolle_Invalid_Value_Throws()
+    {
+        var jsonString = "{\"Foo\": \"NONSENSE\"}";
+        var settings = new Newtonsoft.Json.JsonSerializerSettings()
+        {
+            Converters =
+            {
+                new NewtonsoftMarktteilnehmerrolleStringEnumConverter(),
+                new StringEnumConverter(),
+            },
+        };
+        var act = () =>
+            Newtonsoft.Json.JsonConvert.DeserializeObject<ClassWithNullableMarktteilnehmerrolle>(
+                jsonString,
+                settings
+            );
+        act.Should().Throw<Newtonsoft.Json.JsonSerializationException>().WithMessage("*NONSENSE*");
+    }
+
+    [TestMethod]
+    public void Test_SystemText_Marktteilnehmerrolle_Invalid_Value_Throws()
+    {
+        var jsonString = "{\"Foo\": \"NONSENSE\"}";
+        var settings = new JsonSerializerOptions
+        {
+            Converters = { new SystemTextMarktteilnehmerrolleStringEnumConverter() },
+        };
+        var act = () =>
+            System.Text.Json.JsonSerializer.Deserialize<ClassWithNonNullableMarktteilnehmerrolle>(
+                jsonString,
+                settings
+            );
+        act.Should().Throw<System.Text.Json.JsonException>().WithMessage("*NONSENSE*");
+    }
 }

--- a/BO4ETestProject/TestStringEnumConverter.cs
+++ b/BO4ETestProject/TestStringEnumConverter.cs
@@ -1048,6 +1048,57 @@ public class TestStringEnumConverter
     }
 
     [TestMethod]
+    public void Test_Marktteilnehmer_Deserialization_With_Object_Rolle_SystemText()
+    {
+        var jsonString = "{\"rolle\": {\"code\": \"empfaenger\"}}";
+
+        var actual = System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(
+            jsonString
+        );
+
+        actual.Should().NotBeNull();
+        actual.Rolle.Should().Be(Marktteilnehmerrolle.EMPFAENGER);
+    }
+
+    [TestMethod]
+    public void Test_Marktteilnehmer_Deserialization_With_Object_Rolle_Fallback_SystemText()
+    {
+        var jsonString =
+            "{\"rolle\": {\"bezeichnung\": \"Lieferant\", \"legacy\": \"empfaenger\"}}";
+
+        var actual = System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(
+            jsonString
+        );
+
+        actual.Should().NotBeNull();
+        actual.Rolle.Should().Be(Marktteilnehmerrolle.EMPFAENGER);
+    }
+
+    [TestMethod]
+    public void Test_Marktteilnehmer_Deserialization_With_Unknown_Object_Rolle_SystemText()
+    {
+        var jsonString = "{\"rolle\": {\"code\": \"LF\", \"bezeichnung\": \"Lieferant\"}}";
+
+        var actual = System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(
+            jsonString
+        );
+
+        actual.Should().NotBeNull();
+        actual.Rolle.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void Test_Marktteilnehmer_Deserialization_With_Invalid_String_Rolle_SystemText_Throws()
+    {
+        var jsonString = "{\"rolle\": \"LF\"}";
+
+        var act = () =>
+            System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(jsonString);
+
+        act.Should().Throw<System.Text.Json.JsonException>().WithMessage("*LF*");
+    }
+
+    [TestMethod]
     [DataRow("anderepartei", Marktteilnehmerrolle.ANDERE_PARTEI)]
     [DataRow("ANDERE_PARTEI", Marktteilnehmerrolle.ANDERE_PARTEI)]
     [DataRow("EMPFAENGER", Marktteilnehmerrolle.EMPFAENGER)]

--- a/BO4ETestProject/TestStringEnumConverter.cs
+++ b/BO4ETestProject/TestStringEnumConverter.cs
@@ -1013,6 +1013,44 @@ public class TestStringEnumConverter
     [DataRow("anderepartei", Marktteilnehmerrolle.ANDERE_PARTEI)]
     [DataRow("ANDERE_PARTEI", Marktteilnehmerrolle.ANDERE_PARTEI)]
     [DataRow("EMPFAENGER", Marktteilnehmerrolle.EMPFAENGER)]
+    public void Test_Marktteilnehmer_Deserialization_Default_Settings_Newtonsoft(
+        string jsonValue,
+        Marktteilnehmerrolle expectedRolle
+    )
+    {
+        // Proves that the type-level [JsonConverter] attribute on the enum works
+        // for the actual Marktteilnehmer BO without any converter registration.
+        var jsonString = "{\"rolle\": \"" + jsonValue + "\"}";
+        var actual = Newtonsoft.Json.JsonConvert.DeserializeObject<BO4E.BO.Marktteilnehmer>(
+            jsonString
+        );
+        actual.Should().NotBeNull();
+        actual.Rolle.Should().Be(expectedRolle);
+    }
+
+    [TestMethod]
+    [DataRow("anderepartei", Marktteilnehmerrolle.ANDERE_PARTEI)]
+    [DataRow("ANDERE_PARTEI", Marktteilnehmerrolle.ANDERE_PARTEI)]
+    [DataRow("EMPFAENGER", Marktteilnehmerrolle.EMPFAENGER)]
+    public void Test_Marktteilnehmer_Deserialization_Default_Settings_SystemText(
+        string jsonValue,
+        Marktteilnehmerrolle expectedRolle
+    )
+    {
+        // Proves that the property-level [JsonConverter] attribute on Marktteilnehmer.Rolle
+        // works without any converter registration or lenient options.
+        var jsonString = "{\"rolle\": \"" + jsonValue + "\"}";
+        var actual = System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(
+            jsonString
+        );
+        actual.Should().NotBeNull();
+        actual.Rolle.Should().Be(expectedRolle);
+    }
+
+    [TestMethod]
+    [DataRow("anderepartei", Marktteilnehmerrolle.ANDERE_PARTEI)]
+    [DataRow("ANDERE_PARTEI", Marktteilnehmerrolle.ANDERE_PARTEI)]
+    [DataRow("EMPFAENGER", Marktteilnehmerrolle.EMPFAENGER)]
     public void Test_Newtonsoft_Marktteilnehmerrolle_Default_Settings(
         string jsonValue,
         Marktteilnehmerrolle expectedRolle

--- a/BO4ETestProject/TestStringEnumConverter.cs
+++ b/BO4ETestProject/TestStringEnumConverter.cs
@@ -767,4 +767,245 @@ public class TestStringEnumConverter
         var reSerializedJsonString = System.Text.Json.JsonSerializer.Serialize(result);
         reSerializedJsonString.Should().Contain("MEHRMINDERMENGENABRECHNUNG");
     }
+
+    public class ClassWithNullableMarktteilnehmerrolle
+    {
+        public Marktteilnehmerrolle? Foo { get; set; }
+    }
+
+    public class ClassWithNonNullableMarktteilnehmerrolle
+    {
+        public Marktteilnehmerrolle Foo { get; set; }
+    }
+
+    [TestMethod]
+    [DataRow("anderepartei", Marktteilnehmerrolle.ANDERE_PARTEI, false)]
+    [DataRow("ANDEREPARTEI", Marktteilnehmerrolle.ANDERE_PARTEI, false)]
+    [DataRow("ANDERE_PARTEI", Marktteilnehmerrolle.ANDERE_PARTEI, false)]
+    [DataRow("EMPFAENGER", Marktteilnehmerrolle.EMPFAENGER, false)]
+    [DataRow(null, null, false)]
+    [DataRow("anderepartei", Marktteilnehmerrolle.ANDERE_PARTEI, true)]
+    [DataRow("ANDEREPARTEI", Marktteilnehmerrolle.ANDERE_PARTEI, true)]
+    [DataRow("ANDERE_PARTEI", Marktteilnehmerrolle.ANDERE_PARTEI, true)]
+    [DataRow("EMPFAENGER", Marktteilnehmerrolle.EMPFAENGER, true)]
+    [DataRow(null, null, true)]
+    public void Test_System_Text_Marktteilnehmerrolle_Legacy_Converter_With_Nullable(
+        string? jsonValue,
+        Marktteilnehmerrolle? expectedMarktteilnehmerrolle,
+        bool useMostLenient
+    )
+    {
+        string jsonString;
+        if (jsonValue != null)
+        {
+            jsonString = "{\"Foo\": \"" + jsonValue + "\"}";
+        }
+        else
+        {
+            jsonString = "{\"Foo\": null}";
+        }
+
+        JsonSerializerOptions settings;
+        if (useMostLenient)
+        {
+            settings = LenientParsing.MOST_LENIENT.GetJsonSerializerOptions();
+        }
+        else
+        {
+            settings = new JsonSerializerOptions
+            {
+                Converters = { new SystemTextNullableMarktteilnehmerrolleStringEnumConverter() },
+            };
+        }
+
+        var actual =
+            System.Text.Json.JsonSerializer.Deserialize<ClassWithNullableMarktteilnehmerrolle>(
+                jsonString,
+                settings
+            );
+        actual.Should().NotBeNull();
+        actual.Foo.Should().Be(expectedMarktteilnehmerrolle);
+
+        var reSerializedJsonString = System.Text.Json.JsonSerializer.Serialize(actual, settings);
+        reSerializedJsonString.Should().Contain(expectedMarktteilnehmerrolle?.ToString() ?? "null");
+    }
+
+    [TestMethod]
+    [DataRow("anderepartei", Marktteilnehmerrolle.ANDERE_PARTEI, false)]
+    [DataRow("ANDEREPARTEI", Marktteilnehmerrolle.ANDERE_PARTEI, false)]
+    [DataRow("ANDERE_PARTEI", Marktteilnehmerrolle.ANDERE_PARTEI, false)]
+    [DataRow("EMPFAENGER", Marktteilnehmerrolle.EMPFAENGER, false)]
+    [DataRow("anderepartei", Marktteilnehmerrolle.ANDERE_PARTEI, true)]
+    [DataRow("ANDEREPARTEI", Marktteilnehmerrolle.ANDERE_PARTEI, true)]
+    [DataRow("ANDERE_PARTEI", Marktteilnehmerrolle.ANDERE_PARTEI, true)]
+    [DataRow("EMPFAENGER", Marktteilnehmerrolle.EMPFAENGER, true)]
+    public void Test_System_Text_Marktteilnehmerrolle_Legacy_Converter_With_Non_Nullable(
+        string? jsonValue,
+        Marktteilnehmerrolle expectedMarktteilnehmerrolle,
+        bool useMostLenient
+    )
+    {
+        string jsonString = "{\"Foo\": \"" + jsonValue + "\"}";
+
+        JsonSerializerOptions settings;
+        if (useMostLenient)
+        {
+            settings = LenientParsing.MOST_LENIENT.GetJsonSerializerOptions();
+        }
+        else
+        {
+            settings = new JsonSerializerOptions
+            {
+                Converters = { new SystemTextMarktteilnehmerrolleStringEnumConverter() },
+            };
+        }
+        var actual =
+            System.Text.Json.JsonSerializer.Deserialize<ClassWithNonNullableMarktteilnehmerrolle>(
+                jsonString,
+                settings
+            );
+        actual.Should().NotBeNull();
+        actual.Foo.Should().Be(expectedMarktteilnehmerrolle);
+
+        var reSerializedJsonString = System.Text.Json.JsonSerializer.Serialize(actual, settings);
+        reSerializedJsonString.Should().Contain(expectedMarktteilnehmerrolle.ToString());
+    }
+
+    [TestMethod]
+    [DataRow("anderepartei", Marktteilnehmerrolle.ANDERE_PARTEI, false)]
+    [DataRow("ANDEREPARTEI", Marktteilnehmerrolle.ANDERE_PARTEI, false)]
+    [DataRow("ANDERE_PARTEI", Marktteilnehmerrolle.ANDERE_PARTEI, false)]
+    [DataRow("EMPFAENGER", Marktteilnehmerrolle.EMPFAENGER, false)]
+    [DataRow(null, null, false)]
+    [DataRow("anderepartei", Marktteilnehmerrolle.ANDERE_PARTEI, true)]
+    [DataRow("ANDEREPARTEI", Marktteilnehmerrolle.ANDERE_PARTEI, true)]
+    [DataRow("ANDERE_PARTEI", Marktteilnehmerrolle.ANDERE_PARTEI, true)]
+    [DataRow("EMPFAENGER", Marktteilnehmerrolle.EMPFAENGER, true)]
+    [DataRow(null, null, true)]
+    public void Test_Newtonsoft_Marktteilnehmerrolle_Legacy_Converter_With_Nullable(
+        string? jsonValue,
+        Marktteilnehmerrolle? expectedMarktteilnehmerrolle,
+        bool useMostLenient
+    )
+    {
+        string jsonString;
+        if (jsonValue != null)
+        {
+            jsonString = "{\"Foo\": \"" + jsonValue + "\"}";
+        }
+        else
+        {
+            jsonString = "{\"Foo\": null}";
+        }
+
+        Newtonsoft.Json.JsonSerializerSettings settings;
+        if (useMostLenient)
+        {
+            settings = LenientParsing.MOST_LENIENT.GetJsonSerializerSettings();
+        }
+        else
+        {
+            settings = new Newtonsoft.Json.JsonSerializerSettings()
+            {
+                Converters =
+                {
+                    new NewtonsoftMarktteilnehmerrolleStringEnumConverter(),
+                    new StringEnumConverter(),
+                },
+            };
+        }
+        var actual =
+            Newtonsoft.Json.JsonConvert.DeserializeObject<ClassWithNullableMarktteilnehmerrolle>(
+                jsonString,
+                settings
+            );
+        actual.Should().NotBeNull();
+        actual.Foo.Should().Be(expectedMarktteilnehmerrolle);
+
+        var reSerializedJsonString = Newtonsoft.Json.JsonConvert.SerializeObject(actual, settings);
+        reSerializedJsonString.Should().Contain(expectedMarktteilnehmerrolle?.ToString() ?? "null");
+    }
+
+    [TestMethod]
+    [DataRow("anderepartei", Marktteilnehmerrolle.ANDERE_PARTEI, true)]
+    [DataRow("ANDEREPARTEI", Marktteilnehmerrolle.ANDERE_PARTEI, true)]
+    [DataRow("ANDERE_PARTEI", Marktteilnehmerrolle.ANDERE_PARTEI, true)]
+    [DataRow("EMPFAENGER", Marktteilnehmerrolle.EMPFAENGER, true)]
+    [DataRow("anderepartei", Marktteilnehmerrolle.ANDERE_PARTEI, false)]
+    [DataRow("ANDEREPARTEI", Marktteilnehmerrolle.ANDERE_PARTEI, false)]
+    [DataRow("ANDERE_PARTEI", Marktteilnehmerrolle.ANDERE_PARTEI, false)]
+    [DataRow("EMPFAENGER", Marktteilnehmerrolle.EMPFAENGER, false)]
+    public void Test_Newtonsoft_Marktteilnehmerrolle_Legacy_Converter_With_Non_Nullable(
+        string? jsonValue,
+        Marktteilnehmerrolle expectedMarktteilnehmerrolle,
+        bool useMostLenient
+    )
+    {
+        string jsonString = "{\"Foo\": \"" + jsonValue + "\"}";
+        Newtonsoft.Json.JsonSerializerSettings settings;
+        if (useMostLenient)
+        {
+            settings = LenientParsing.MOST_LENIENT.GetJsonSerializerSettings();
+        }
+        else
+        {
+            settings = new Newtonsoft.Json.JsonSerializerSettings()
+            {
+                Converters =
+                {
+                    new NewtonsoftMarktteilnehmerrolleStringEnumConverter(),
+                    new StringEnumConverter(),
+                },
+            };
+        }
+
+        var actual =
+            Newtonsoft.Json.JsonConvert.DeserializeObject<ClassWithNonNullableMarktteilnehmerrolle>(
+                jsonString,
+                settings
+            );
+        actual.Should().NotBeNull();
+        actual.Foo.Should().Be(expectedMarktteilnehmerrolle);
+
+        var reSerializedJsonString = Newtonsoft.Json.JsonConvert.SerializeObject(actual, settings);
+        reSerializedJsonString.Should().Contain(expectedMarktteilnehmerrolle.ToString());
+    }
+
+    [TestMethod]
+    [DataRow("anderepartei", Marktteilnehmerrolle.ANDERE_PARTEI)]
+    [DataRow("ANDERE_PARTEI", Marktteilnehmerrolle.ANDERE_PARTEI)]
+    [DataRow("EMPFAENGER", Marktteilnehmerrolle.EMPFAENGER)]
+    public void Test_Marktteilnehmer_Deserialization_With_Legacy_Rolle_Newtonsoft(
+        string jsonValue,
+        Marktteilnehmerrolle expectedRolle
+    )
+    {
+        var jsonString = "{\"rolle\": \"" + jsonValue + "\"}";
+        var settings = LenientParsing.MOST_LENIENT.GetJsonSerializerSettings();
+        var actual = Newtonsoft.Json.JsonConvert.DeserializeObject<BO4E.BO.Marktteilnehmer>(
+            jsonString,
+            settings
+        );
+        actual.Should().NotBeNull();
+        actual.Rolle.Should().Be(expectedRolle);
+    }
+
+    [TestMethod]
+    [DataRow("anderepartei", Marktteilnehmerrolle.ANDERE_PARTEI)]
+    [DataRow("ANDERE_PARTEI", Marktteilnehmerrolle.ANDERE_PARTEI)]
+    [DataRow("EMPFAENGER", Marktteilnehmerrolle.EMPFAENGER)]
+    public void Test_Marktteilnehmer_Deserialization_With_Legacy_Rolle_SystemText(
+        string jsonValue,
+        Marktteilnehmerrolle expectedRolle
+    )
+    {
+        var jsonString = "{\"rolle\": \"" + jsonValue + "\"}";
+        var settings = LenientParsing.MOST_LENIENT.GetJsonSerializerOptions();
+        var actual = System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(
+            jsonString,
+            settings
+        );
+        actual.Should().NotBeNull();
+        actual.Rolle.Should().Be(expectedRolle);
+    }
 }


### PR DESCRIPTION
## Summary
- Add `Marktteilnehmerrolle` JSON converter coverage for legacy scalar values and object-shaped `Marktteilnehmer.rolle` payloads.
- Handle object-shaped `Marktteilnehmer.rolle` values in the System.Text.Json nullable converter by extracting a parseable scalar from legacy object properties.
- Preserve scalar behavior: direct invalid string values still throw, while unparseable legacy object payloads deserialize as `null`.

## Exception
`System.Text.Json.JsonException: The JSON value could not be converted to System.Nullable`1[BO4E.ENUM.Marktteilnehmerrolle]. Path: $.rolle`

Inner exception: `Cannot get the value of a token type 'StartObject' as a string.`

## Verification
- `dotnet csharpier check BO4E\\meta\\LenientConverters\\SystemTextNullableMarktteilnehmerrolleStringEnumConverter.cs BO4ETestProject\\TestStringEnumConverter.cs`
- `dotnet test BO4ETestProject\\TestBO4E.csproj --filter Marktteilnehmerrolle --no-restore --verbosity minimal` passed 48/48.