### PR TITLE
fix: handle object-shaped Marktteilnehmerrolle values

### DIFF
--- a/BO4E/meta/LenientConverters/SystemTextNullableMarktteilnehmerrolleStringEnumConverter.cs
+++ b/BO4E/meta/LenientConverters/SystemTextNullableMarktteilnehmerrolleStringEnumConverter.cs
@@ -66,7 +66,7 @@ public class SystemTextNullableMarktteilnehmerrolleStringEnumConverter
             JsonValueKind.String => TryParseString(property.GetString(), out var result)
                 ? result
                 : null,
-            JsonValueKind.Number when property.TryGetInt64(out var integerValue) => Enum.IsDefined(
+            JsonValueKind.Number when property.TryGetInt32(out var integerValue) => Enum.IsDefined(
                 typeof(Marktteilnehmerrolle),
                 integerValue
             )

--- a/BO4E/meta/LenientConverters/SystemTextNullableMarktteilnehmerrolleStringEnumConverter.cs
+++ b/BO4E/meta/LenientConverters/SystemTextNullableMarktteilnehmerrolleStringEnumConverter.cs
@@ -97,7 +97,16 @@ public class SystemTextNullableMarktteilnehmerrolleStringEnumConverter
             return true;
         }
 
-        return Enum.TryParse(normalized, out result);
+        if (
+            Enum.TryParse(normalized, out result)
+            && Enum.IsDefined(typeof(Marktteilnehmerrolle), result)
+        )
+        {
+            return true;
+        }
+
+        result = default;
+        return false;
     }
 
     /// <inheritdoc />

--- a/BO4E/meta/LenientConverters/SystemTextNullableMarktteilnehmerrolleStringEnumConverter.cs
+++ b/BO4E/meta/LenientConverters/SystemTextNullableMarktteilnehmerrolleStringEnumConverter.cs
@@ -56,14 +56,6 @@ public class SystemTextNullableMarktteilnehmerrolleStringEnumConverter
             }
         }
 
-        foreach (var property in rolleObject.EnumerateObject())
-        {
-            if (TryParseProperty(property.Value, out var parsed))
-            {
-                return parsed;
-            }
-        }
-
         return null;
     }
 
@@ -74,8 +66,12 @@ public class SystemTextNullableMarktteilnehmerrolleStringEnumConverter
             JsonValueKind.String => TryParseString(property.GetString(), out var result)
                 ? result
                 : null,
-            JsonValueKind.Number when property.TryGetInt64(out var integerValue) =>
-                (Marktteilnehmerrolle)Enum.ToObject(typeof(Marktteilnehmerrolle), integerValue),
+            JsonValueKind.Number when property.TryGetInt64(out var integerValue) => Enum.IsDefined(
+                typeof(Marktteilnehmerrolle),
+                integerValue
+            )
+                ? (Marktteilnehmerrolle)Enum.ToObject(typeof(Marktteilnehmerrolle), integerValue)
+                : null,
             JsonValueKind.Null => null,
             _ => null,
         };

--- a/BO4E/meta/LenientConverters/SystemTextNullableMarktteilnehmerrolleStringEnumConverter.cs
+++ b/BO4E/meta/LenientConverters/SystemTextNullableMarktteilnehmerrolleStringEnumConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json;
 using BO4E.ENUM;
 
 namespace BO4E.meta.LenientConverters;
@@ -14,6 +15,8 @@ namespace BO4E.meta.LenientConverters;
 public class SystemTextNullableMarktteilnehmerrolleStringEnumConverter
     : System.Text.Json.Serialization.JsonConverter<Marktteilnehmerrolle?>
 {
+    private static readonly string[] LegacyObjectPropertyNames = ["code", "name", "value", "wert"];
+
     /// <inheritdoc />
     public override Marktteilnehmerrolle? Read(
         ref System.Text.Json.Utf8JsonReader reader,
@@ -30,17 +33,82 @@ public class SystemTextNullableMarktteilnehmerrolleStringEnumConverter
             var integerValue = reader.GetInt64();
             return (Marktteilnehmerrolle)Enum.ToObject(typeof(Marktteilnehmerrolle), integerValue);
         }
+        if (reader.TokenType == System.Text.Json.JsonTokenType.StartObject)
+        {
+            using var document = JsonDocument.ParseValue(ref reader);
+            return ParseLegacyObject(document.RootElement, typeToConvert);
+        }
         string? enumString = reader.GetString();
 
-        return enumString?.ToUpper() switch
+        return ParseString(enumString, typeToConvert);
+    }
+
+    private static Marktteilnehmerrolle? ParseLegacyObject(
+        JsonElement rolleObject,
+        Type typeToConvert
+    )
+    {
+        foreach (var propertyName in LegacyObjectPropertyNames)
         {
-            "ANDEREPARTEI" => Marktteilnehmerrolle.ANDERE_PARTEI,
-            _ => Enum.TryParse(enumString?.ToUpper(), out Marktteilnehmerrolle result)
+            if (
+                rolleObject.TryGetProperty(propertyName, out var property)
+                && TryParseProperty(property, typeToConvert, out var parsed)
+            )
+            {
+                return parsed;
+            }
+        }
+
+        foreach (var property in rolleObject.EnumerateObject())
+        {
+            if (TryParseProperty(property.Value, typeToConvert, out var parsed))
+            {
+                return parsed;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryParseProperty(
+        JsonElement property,
+        Type typeToConvert,
+        out Marktteilnehmerrolle? parsed
+    )
+    {
+        parsed = property.ValueKind switch
+        {
+            JsonValueKind.String => TryParseString(property.GetString(), out var result)
                 ? result
-                : throw new System.Text.Json.JsonException(
-                    $"Invalid value for {typeToConvert}: {enumString}"
-                ),
+                : null,
+            JsonValueKind.Number when property.TryGetInt64(out var integerValue) =>
+                (Marktteilnehmerrolle)Enum.ToObject(typeof(Marktteilnehmerrolle), integerValue),
+            JsonValueKind.Null => null,
+            _ => null,
         };
+
+        return parsed is not null;
+    }
+
+    private static Marktteilnehmerrolle ParseString(string? enumString, Type typeToConvert)
+    {
+        return TryParseString(enumString, out var result)
+            ? result
+            : throw new System.Text.Json.JsonException(
+                $"Invalid value for {typeToConvert}: {enumString}"
+            );
+    }
+
+    private static bool TryParseString(string? enumString, out Marktteilnehmerrolle result)
+    {
+        var normalized = enumString?.ToUpper();
+        if (normalized == "ANDEREPARTEI")
+        {
+            result = Marktteilnehmerrolle.ANDERE_PARTEI;
+            return true;
+        }
+
+        return Enum.TryParse(normalized, out result);
     }
 
     /// <inheritdoc />

--- a/BO4E/meta/LenientConverters/SystemTextNullableMarktteilnehmerrolleStringEnumConverter.cs
+++ b/BO4E/meta/LenientConverters/SystemTextNullableMarktteilnehmerrolleStringEnumConverter.cs
@@ -36,23 +36,20 @@ public class SystemTextNullableMarktteilnehmerrolleStringEnumConverter
         if (reader.TokenType == System.Text.Json.JsonTokenType.StartObject)
         {
             using var document = JsonDocument.ParseValue(ref reader);
-            return ParseLegacyObject(document.RootElement, typeToConvert);
+            return ParseLegacyObject(document.RootElement);
         }
         string? enumString = reader.GetString();
 
         return ParseString(enumString, typeToConvert);
     }
 
-    private static Marktteilnehmerrolle? ParseLegacyObject(
-        JsonElement rolleObject,
-        Type typeToConvert
-    )
+    private static Marktteilnehmerrolle? ParseLegacyObject(JsonElement rolleObject)
     {
         foreach (var propertyName in LegacyObjectPropertyNames)
         {
             if (
                 rolleObject.TryGetProperty(propertyName, out var property)
-                && TryParseProperty(property, typeToConvert, out var parsed)
+                && TryParseProperty(property, out var parsed)
             )
             {
                 return parsed;
@@ -61,7 +58,7 @@ public class SystemTextNullableMarktteilnehmerrolleStringEnumConverter
 
         foreach (var property in rolleObject.EnumerateObject())
         {
-            if (TryParseProperty(property.Value, typeToConvert, out var parsed))
+            if (TryParseProperty(property.Value, out var parsed))
             {
                 return parsed;
             }
@@ -70,11 +67,7 @@ public class SystemTextNullableMarktteilnehmerrolleStringEnumConverter
         return null;
     }
 
-    private static bool TryParseProperty(
-        JsonElement property,
-        Type typeToConvert,
-        out Marktteilnehmerrolle? parsed
-    )
+    private static bool TryParseProperty(JsonElement property, out Marktteilnehmerrolle? parsed)
     {
         parsed = property.ValueKind switch
         {

--- a/BO4ETestProject/TestStringEnumConverter.cs
+++ b/BO4ETestProject/TestStringEnumConverter.cs
@@ -1048,6 +1048,57 @@ public class TestStringEnumConverter
     }
 
     [TestMethod]
+    public void Test_Marktteilnehmer_Deserialization_With_Object_Rolle_SystemText()
+    {
+        var jsonString = "{\"rolle\": {\"code\": \"empfaenger\"}}";
+
+        var actual = System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(
+            jsonString
+        );
+
+        actual.Should().NotBeNull();
+        actual.Rolle.Should().Be(Marktteilnehmerrolle.EMPFAENGER);
+    }
+
+    [TestMethod]
+    public void Test_Marktteilnehmer_Deserialization_With_Object_Rolle_Fallback_SystemText()
+    {
+        var jsonString =
+            "{\"rolle\": {\"bezeichnung\": \"Lieferant\", \"legacy\": \"empfaenger\"}}";
+
+        var actual = System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(
+            jsonString
+        );
+
+        actual.Should().NotBeNull();
+        actual.Rolle.Should().Be(Marktteilnehmerrolle.EMPFAENGER);
+    }
+
+    [TestMethod]
+    public void Test_Marktteilnehmer_Deserialization_With_Unknown_Object_Rolle_SystemText()
+    {
+        var jsonString = "{\"rolle\": {\"code\": \"LF\", \"bezeichnung\": \"Lieferant\"}}";
+
+        var actual = System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(
+            jsonString
+        );
+
+        actual.Should().NotBeNull();
+        actual.Rolle.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void Test_Marktteilnehmer_Deserialization_With_Invalid_String_Rolle_SystemText_Throws()
+    {
+        var jsonString = "{\"rolle\": \"LF\"}";
+
+        var act = () =>
+            System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(jsonString);
+
+        act.Should().Throw<System.Text.Json.JsonException>().WithMessage("*LF*");
+    }
+
+    [TestMethod]
     [DataRow("anderepartei", Marktteilnehmerrolle.ANDERE_PARTEI)]
     [DataRow("ANDERE_PARTEI", Marktteilnehmerrolle.ANDERE_PARTEI)]
     [DataRow("EMPFAENGER", Marktteilnehmerrolle.EMPFAENGER)]

--- a/BO4ETestProject/TestStringEnumConverter.cs
+++ b/BO4ETestProject/TestStringEnumConverter.cs
@@ -1058,16 +1058,15 @@ public class TestStringEnumConverter
                 jsonString
             );
 
-        deserializing.Should().NotThrow<System.Text.Json.JsonException>();
+        deserializing.Should().NotThrow();
         actual.Should().NotBeNull();
         actual.Rolle.Should().Be(Marktteilnehmerrolle.EMPFAENGER);
     }
 
     [TestMethod]
-    public void Test_Marktteilnehmer_Deserialization_With_Object_Rolle_Fallback_Does_Not_Throw_StartObject_JsonException_SystemText()
+    public void Test_Marktteilnehmer_Deserialization_With_Non_Code_Object_Rolle_Does_Not_Parse_Unrelated_Properties_SystemText()
     {
-        var jsonString =
-            "{\"rolle\": {\"bezeichnung\": \"Lieferant\", \"legacy\": \"empfaenger\"}}";
+        var jsonString = "{\"rolle\": {\"bezeichnung\": \"empfaenger\"}}";
         BO4E.BO.Marktteilnehmer? actual = null;
 
         var deserializing = () =>
@@ -1075,9 +1074,9 @@ public class TestStringEnumConverter
                 jsonString
             );
 
-        deserializing.Should().NotThrow<System.Text.Json.JsonException>();
+        deserializing.Should().NotThrow();
         actual.Should().NotBeNull();
-        actual.Rolle.Should().Be(Marktteilnehmerrolle.EMPFAENGER);
+        actual.Rolle.Should().BeNull();
     }
 
     [TestMethod]
@@ -1091,7 +1090,23 @@ public class TestStringEnumConverter
                 jsonString
             );
 
-        deserializing.Should().NotThrow<System.Text.Json.JsonException>();
+        deserializing.Should().NotThrow();
+        actual.Should().NotBeNull();
+        actual.Rolle.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void Test_Marktteilnehmer_Deserialization_With_Unknown_Numeric_Object_Rolle_Does_Not_Create_Undefined_Enum_SystemText()
+    {
+        var jsonString = "{\"rolle\": {\"code\": 999}}";
+        BO4E.BO.Marktteilnehmer? actual = null;
+
+        var deserializing = () =>
+            actual = System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(
+                jsonString
+            );
+
+        deserializing.Should().NotThrow();
         actual.Should().NotBeNull();
         actual.Rolle.Should().BeNull();
     }

--- a/BO4ETestProject/TestStringEnumConverter.cs
+++ b/BO4ETestProject/TestStringEnumConverter.cs
@@ -1112,6 +1112,22 @@ public class TestStringEnumConverter
     }
 
     [TestMethod]
+    public void Test_Marktteilnehmer_Deserialization_With_Unknown_Numeric_String_Object_Rolle_Does_Not_Create_Undefined_Enum_SystemText()
+    {
+        var jsonString = "{\"rolle\": {\"code\": \"999\"}}";
+        BO4E.BO.Marktteilnehmer? actual = null;
+
+        var deserializing = () =>
+            actual = System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(
+                jsonString
+            );
+
+        deserializing.Should().NotThrow();
+        actual.Should().NotBeNull();
+        actual.Rolle.Should().BeNull();
+    }
+
+    [TestMethod]
     public void Test_Marktteilnehmer_Deserialization_With_Numeric_Object_Rolle_SystemText()
     {
         var jsonString = "{\"rolle\": {\"code\": 1}}";
@@ -1136,6 +1152,17 @@ public class TestStringEnumConverter
             System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(jsonString);
 
         act.Should().Throw<System.Text.Json.JsonException>().WithMessage("*LF*");
+    }
+
+    [TestMethod]
+    public void Test_Marktteilnehmer_Deserialization_With_Undefined_Numeric_String_Rolle_SystemText_Throws()
+    {
+        var jsonString = "{\"rolle\": \"999\"}";
+
+        var act = () =>
+            System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(jsonString);
+
+        act.Should().Throw<System.Text.Json.JsonException>().WithMessage("*999*");
     }
 
     [TestMethod]

--- a/BO4ETestProject/TestStringEnumConverter.cs
+++ b/BO4ETestProject/TestStringEnumConverter.cs
@@ -1112,6 +1112,22 @@ public class TestStringEnumConverter
     }
 
     [TestMethod]
+    public void Test_Marktteilnehmer_Deserialization_With_Numeric_Object_Rolle_SystemText()
+    {
+        var jsonString = "{\"rolle\": {\"code\": 1}}";
+        BO4E.BO.Marktteilnehmer? actual = null;
+
+        var deserializing = () =>
+            actual = System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(
+                jsonString
+            );
+
+        deserializing.Should().NotThrow();
+        actual.Should().NotBeNull();
+        actual.Rolle.Should().Be(Marktteilnehmerrolle.EMPFAENGER);
+    }
+
+    [TestMethod]
     public void Test_Marktteilnehmer_Deserialization_With_Invalid_String_Rolle_SystemText_Throws()
     {
         var jsonString = "{\"rolle\": \"LF\"}";

--- a/BO4ETestProject/TestStringEnumConverter.cs
+++ b/BO4ETestProject/TestStringEnumConverter.cs
@@ -1048,41 +1048,50 @@ public class TestStringEnumConverter
     }
 
     [TestMethod]
-    public void Test_Marktteilnehmer_Deserialization_With_Object_Rolle_SystemText()
+    public void Test_Marktteilnehmer_Deserialization_With_Object_Rolle_Does_Not_Throw_StartObject_JsonException_SystemText()
     {
         var jsonString = "{\"rolle\": {\"code\": \"empfaenger\"}}";
+        BO4E.BO.Marktteilnehmer? actual = null;
 
-        var actual = System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(
-            jsonString
-        );
+        var deserializing = () =>
+            actual = System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(
+                jsonString
+            );
 
+        deserializing.Should().NotThrow<System.Text.Json.JsonException>();
         actual.Should().NotBeNull();
         actual.Rolle.Should().Be(Marktteilnehmerrolle.EMPFAENGER);
     }
 
     [TestMethod]
-    public void Test_Marktteilnehmer_Deserialization_With_Object_Rolle_Fallback_SystemText()
+    public void Test_Marktteilnehmer_Deserialization_With_Object_Rolle_Fallback_Does_Not_Throw_StartObject_JsonException_SystemText()
     {
         var jsonString =
             "{\"rolle\": {\"bezeichnung\": \"Lieferant\", \"legacy\": \"empfaenger\"}}";
+        BO4E.BO.Marktteilnehmer? actual = null;
 
-        var actual = System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(
-            jsonString
-        );
+        var deserializing = () =>
+            actual = System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(
+                jsonString
+            );
 
+        deserializing.Should().NotThrow<System.Text.Json.JsonException>();
         actual.Should().NotBeNull();
         actual.Rolle.Should().Be(Marktteilnehmerrolle.EMPFAENGER);
     }
 
     [TestMethod]
-    public void Test_Marktteilnehmer_Deserialization_With_Unknown_Object_Rolle_SystemText()
+    public void Test_Marktteilnehmer_Deserialization_With_Unknown_Object_Rolle_Does_Not_Throw_StartObject_JsonException_SystemText()
     {
         var jsonString = "{\"rolle\": {\"code\": \"LF\", \"bezeichnung\": \"Lieferant\"}}";
+        BO4E.BO.Marktteilnehmer? actual = null;
 
-        var actual = System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(
-            jsonString
-        );
+        var deserializing = () =>
+            actual = System.Text.Json.JsonSerializer.Deserialize<BO4E.BO.Marktteilnehmer>(
+                jsonString
+            );
 
+        deserializing.Should().NotThrow<System.Text.Json.JsonException>();
         actual.Should().NotBeNull();
         actual.Rolle.Should().BeNull();
     }


### PR DESCRIPTION
## Summary
- Handle object-shaped `Marktteilnehmer.rolle` values in the System.Text.Json nullable `Marktteilnehmerrolle` converter.
- Extract parseable scalar values from legacy object properties and keep scalar enum behavior unchanged.
- Add regression coverage for object-shaped roles, fallback scalar extraction, unknown object payloads, and direct invalid string payloads.

## Exception
`System.Text.Json.JsonException: The JSON value could not be converted to System.Nullable`1[BO4E.ENUM.Marktteilnehmerrolle]. Path: $.rolle`

Inner exception: `Cannot get the value of a token type 'StartObject' as a string.`

## Verification
- `dotnet csharpier check BO4E\\meta\\LenientConverters\\SystemTextNullableMarktteilnehmerrolleStringEnumConverter.cs BO4ETestProject\\TestStringEnumConverter.cs`
- `dotnet test BO4ETestProject\\TestBO4E.csproj --filter Marktteilnehmerrolle --verbosity normal` passed 48/48.