### PR TITLE
DEV-114436: Add CONTRL UCD FehlerCode enum values

### DIFF
--- a/BO4E/ENUM/FehlerCode.cs
+++ b/BO4E/ENUM/FehlerCode.cs
@@ -260,6 +260,34 @@ public enum FehlerCode
     WERT_ZU_LANG,
 
     /// <summary>
+    /// Wert zu kurz
+    /// </summary>
+    [EnumMember(Value = "WERT_ZU_KURZ")]
+    [System.Text.Json.Serialization.JsonStringEnumMemberName("WERT_ZU_KURZ")]
+    WERT_ZU_KURZ,
+
+    /// <summary>
+    /// Ungültige Dezimalbeschreibung
+    /// </summary>
+    [EnumMember(Value = "UNGUELTIGE_DEZIMALBESCHREIBUNG")]
+    [System.Text.Json.Serialization.JsonStringEnumMemberName("UNGUELTIGE_DEZIMALBESCHREIBUNG")]
+    UNGUELTIGE_DEZIMALBESCHREIBUNG,
+
+    /// <summary>
+    /// Ungültige Zeichenart
+    /// </summary>
+    [EnumMember(Value = "UNGUELTIGE_ZEICHENART")]
+    [System.Text.Json.Serialization.JsonStringEnumMemberName("UNGUELTIGE_ZEICHENART")]
+    UNGUELTIGE_ZEICHENART,
+
+    /// <summary>
+    /// Fehlende Ziffer vor dem Dezimalzeichen
+    /// </summary>
+    [EnumMember(Value = "FEHLENDE_ZIFFER_VOR_DEZIMALZEICHEN")]
+    [System.Text.Json.Serialization.JsonStringEnumMemberName("FEHLENDE_ZIFFER_VOR_DEZIMALZEICHEN")]
+    FEHLENDE_ZIFFER_VOR_DEZIMALZEICHEN,
+
+    /// <summary>
     /// Zu viele Wiederholungen
     /// </summary>
     [EnumMember(Value = "WIEDERHOLUNG_UNPLAUSIBEL")]


### PR DESCRIPTION
## Summary
- Add `WERT_ZU_KURZ` (symmetrisch zu `WERT_ZU_LANG`) für UCD-Code 40 (Datenelement zu kurz)
- Add `UNGUELTIGE_DEZIMALBESCHREIBUNG` für UCD-Code 19 (Dezimalnotation ≠ UNA)
- Add `UNGUELTIGE_ZEICHENART` für UCD-Code 37 (falscher Zeichentyp in Datenelement)
- Add `FEHLENDE_ZIFFER_VOR_DEZIMALZEICHEN` für UCD-Code 38 (fehlende Ziffer vor Dezimalzeichen)

Hintergrund: Der edifact-bo4e-converter benötigt präzise BO4E-Werte für CONTRL-Syntaxfehler (DEV-114436). Bisher wurden Fallback-Werte wie `WERT_UNGUELTIG` oder `FORMAT_NICHT_EINGEHALTEN` verwendet, die die BDEW-CONTRL-AHB-Semantik nicht korrekt abbilden.

## Test Plan
- [ ] Alle bestehenden Tests weiterhin grün (1 pre-existing failure in `TestZählerHerstellerKontaktweg` unrelated zu diesen Änderungen)
- [ ] Neue Enum-Werte kompilieren ohne Warnings